### PR TITLE
Pin huggingface-hub version

### DIFF
--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -15,3 +15,4 @@ tensorflow-datasets
 ruff>=0.1.5,<=0.2
 git+https://github.com/mlperf/logging.git
 opencv-python
+huggingface_hub<0.26.0 #https://github.com/AI-Hypercomputer/maxdiffusion/issues/124


### PR DESCRIPTION
Short term solution for https://github.com/AI-Hypercomputer/maxdiffusion/issues/124

Tested:

Via Pip freeze 

```
huggingface-hub==0.25.2
```