### PR TITLE
Update the huggingface_hub version in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ _deps = [
     "filelock",
     "flax>=0.4.1",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.13.2",
+    "huggingface-hub==0.24.7",
     "requests-mock==1.10.0",
     "importlib_metadata",
     "invisible-watermark>=0.2.0",


### PR DESCRIPTION
The pip install command is recommend to launch job in cluster. Updating the setup script will make this command to pick up the correct huggingface version.