### PR TITLE
enable grain and tfrecord for mlperf dataset in SD base_2_base training

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -39,10 +39,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e .
-        pip install -U -r requirements.txt
-        export PATH=$PATH:$HOME/.local/bin
         pip uninstall jax jaxlib libtpu-nightly libtpu -y
-        pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+        bash setup.sh MODE=stable
+        export PATH=$PATH:$HOME/.local/bin
         pip install ruff
         pip install isort
         pip install pytest

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,16 @@
 set -e
 export DEBIAN_FRONTEND=noninteractive
 
+(sudo bash || bash) <<'EOF'
+apt update && \
+apt install -y numactl lsb-release gnupg curl net-tools iproute2 procps lsof git ethtool && \
+export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt update -y && apt -y install gcsfuse
+rm -rf /var/lib/apt/lists/*
+EOF
+
 # Set environment variables from command line arguments
 for ARGUMENT in "$@"; do
   IFS='=' read -r KEY VALUE <<< "$ARGUMENT"

--- a/setup_gcsfuse.sh
+++ b/setup_gcsfuse.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Description:
+# bash setup_gcsfuse.sh DATASET_GCS_BUCKET=maxdiffusion-github-runner-test-assets MOUNT_PATH=/tmp/gcsfuse
+
+set -e -x
+
+# Set environment variables
+for ARGUMENT in "$@"; do
+    IFS='=' read -r KEY VALUE <<< "$ARGUMENT"
+    export "$KEY"="$VALUE"
+    echo "$KEY"="$VALUE"
+done
+
+if [[ -z ${DATASET_GCS_BUCKET} || -z ${MOUNT_PATH} ]]; then
+  echo "Please set arguments: DATASET_GCS_BUCKET and MOUNT_PATH"
+  exit 1
+fi
+
+if [[ "$DATASET_GCS_BUCKET" =~ gs:\/\/ ]] ; then
+    DATASET_GCS_BUCKET="${DATASET_GCS_BUCKET/gs:\/\//}"
+    echo "Removed gs:// from GCS bucket name, GCS bucket is $DATASET_GCS_BUCKET"
+fi
+
+if [[ -d ${MOUNT_PATH} ]]; then
+  echo "$MOUNT_PATH exists, removing..."
+  fusermount -u $MOUNT_PATH || rm -rf $MOUNT_PATH
+fi
+
+mkdir -p $MOUNT_PATH
+
+# see https://cloud.google.com/storage/docs/gcsfuse-cli for all configurable options of gcsfuse CLI
+# Grain uses _PROCESS_MANAGEMENT_MAX_THREADS = 64 (https://github.com/google/grain/blob/main/grain/_src/python/grain_pool.py)
+# Please make sure max-conns-per-host > grain_worker_count * _PROCESS_MANAGEMENT_MAX_THREADS
+
+gcsfuse -o ro --implicit-dirs --http-client-timeout=5s --max-conns-per-host=2000 \
+        --debug_fuse_errors --debug_fuse --debug_gcs --debug_invariants --debug_mutex \
+        --log-file=$HOME/gcsfuse.json "$DATASET_GCS_BUCKET" "$MOUNT_PATH"

--- a/src/maxdiffusion/configs/base_2_base.yml
+++ b/src/maxdiffusion/configs/base_2_base.yml
@@ -155,6 +155,8 @@ jax_cache_dir: ''
 hf_data_dir: ''
 hf_train_files: ''
 hf_access_token: ''
+grain_train_files: ''
+grain_worker_count: 4
 image_column: 'image'
 caption_column: 'text'
 resolution: 512

--- a/src/maxdiffusion/input_pipeline/_grain_data_processing.py
+++ b/src/maxdiffusion/input_pipeline/_grain_data_processing.py
@@ -1,0 +1,79 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import dataclasses
+import glob
+import tensorflow as tf
+import numpy as np
+import grain.python as grain
+
+from maxdiffusion import multihost_dataloading
+
+
+def make_grain_iterator(
+    config,
+    dataloading_host_index,
+    dataloading_host_count,
+    mesh,
+    global_batch_size,
+):
+  """Use Grain data input pipeline with ArrayRecord data format"""
+  data_files = glob.glob(config.grain_train_files)
+  data_source = grain.ArrayRecordDataSource(data_files)
+
+  operations = []
+  operations.append(ParseFeatures())
+  operations.append(grain.Batch(batch_size=global_batch_size // dataloading_host_count, drop_remainder=True))
+
+  index_sampler = grain.IndexSampler(
+      num_records=len(data_source),
+      num_epochs=None,
+      shard_options=grain.ShardOptions(
+          shard_index=dataloading_host_index, shard_count=dataloading_host_count, drop_remainder=True
+      ),
+      shuffle=True,
+      seed=config.seed,
+  )
+
+  dataloader = grain.DataLoader(
+      data_source=data_source,
+      operations=operations,
+      sampler=index_sampler,
+      worker_count=config.grain_worker_count,
+  )
+
+  data_iter = multihost_dataloading.MultiHostDataLoadIterator(dataloader, mesh)
+  return data_iter
+
+
+@dataclasses.dataclass
+class ParseFeatures(grain.MapTransform):
+  """Parse serialized example"""
+
+  def __init__(self):
+    self.feature_description = {
+        "moments": tf.io.FixedLenFeature([], tf.string),
+        "clip_embeddings": tf.io.FixedLenFeature([], tf.string),
+    }
+
+  def map(self, example):
+    def _parse(example):
+      features = tf.io.parse_single_example(example, self.feature_description)
+      moments = tf.io.parse_tensor(np.asarray(features["moments"]), out_type=tf.float32)
+      clip_embeddings = tf.io.parse_tensor(np.asarray(features["clip_embeddings"]), out_type=tf.float32)
+      return {"pixel_values": moments, "input_ids": clip_embeddings}
+
+    return _parse(example)

--- a/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
+++ b/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
@@ -21,6 +21,7 @@ from datasets import load_from_disk, Dataset
 import jax
 
 from maxdiffusion.input_pipeline import _hf_data_processing
+from maxdiffusion.input_pipeline import _grain_data_processing
 from maxdiffusion.input_pipeline import _tfds_data_processing
 from maxdiffusion import multihost_dataloading
 from maxdiffusion.maxdiffusion_utils import tokenize_captions, transform_images, vae_apply
@@ -61,6 +62,14 @@ def make_data_iterator(
         tokenize_fn=tokenize_fn,
         image_transforms_fn=image_transforms_fn,
     )
+  elif config.dataset_type == "grain":
+    return _grain_data_processing.make_grain_iterator(
+        config,
+        dataloading_host_index,
+        dataloading_host_count,
+        mesh,
+        global_batch_size,
+    )
   elif config.dataset_type == "tf":
     return _tfds_data_processing.make_tf_iterator(
         config,
@@ -80,7 +89,7 @@ def make_data_iterator(
         global_batch_size,
     )
   else:
-    assert False, f"Unknown dataset_type {config.dataset_type}, dataset_type must be in (tf, tfrecord, hf)"
+    assert False, f"Unknown dataset_type {config.dataset_type}, dataset_type must be in (tf, tfrecord, hf, grain)"
 
 
 def make_dreambooth_train_iterator(config, mesh, global_batch_size, tokenizer, vae, vae_params):


### PR DESCRIPTION
tfrecord and grain has comparable step time when training base_2_base on v4-128 with per_device_batch_size=1
* tfrecord: https://cloudlogging.app.goo.gl/1PLGpK7g8s2qKGjZ9 
* grain: https://cloudlogging.app.goo.gl/ctUdjujenVFs4BjV6 