### PR TITLE
Fixes build image failure

### DIFF
--- a/maxdiffusion_jax_stable_stack_tpu.Dockerfile
+++ b/maxdiffusion_jax_stable_stack_tpu.Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /deps
 COPY . .
 
 # Install Maxdiffusion jax stable stack requirements
-RUN pip install -r /app/requirements_with_jax_stable_stack.txt
+RUN pip install -r /deps/requirements_with_jax_stable_stack.txt
 
 # Run the script available in JAX-Stable-Stack base image to generate the manifest file
 RUN bash /jax-stable-stack/generate_manifest.sh PREFIX=maxdiffusion COMMIT_HASH=$COMMIT_HASH


### PR DESCRIPTION
Introduced in: https://github.com/AI-Hypercomputer/maxdiffusion/pull/121

Error: 

```
 => ERROR [5/6] RUN pip install -r /app/requirements_with_jax_stable_stack.txt                                                 2.1s
------                                                                                                                              
 > [5/6] RUN pip install -r /app/requirements_with_jax_stable_stack.txt:                                                            
#9 1.790                                                                                                                            
#9 1.790 [notice] A new release of pip is available: 24.2 -> 24.3.1                                                                 
#9 1.790 [notice] To update, run: pip install --upgrade pip
#9 1.791 ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/app/requirements_with_jax_stable_stack.txt'
------
```

Fix: 

Changed to `/deps/requirements_with_jax_stable_stack.txt`

Tested: 

```
bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxdiffusion_jax_stable_stack_0.4.35 MODE=stable_stack PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxdiffusion_jax_stable_stack_0.4.35 BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.35-rev1
```

