### PR TITLE
support grain checkpoint

### DIFF
--- a/docs/data_README.md
+++ b/docs/data_README.md
@@ -6,7 +6,8 @@ Currently MaxDiffusion supports 3 data input pipelines, controlled by the flag `
 | -------- | ---------------- | --------------- | ----------------------- |
 | HuggingFace (hf) | datasets in HuggingFace Hub or local/Cloud Storage | Formats supported in HF Hub: parquet, arrow, json, csv, txt | data are not loaded in memory but streamed from the saved location, good for big dataset | 
 | tf | dataset will be downaloaded form HuggingFace Hub to disk | Formats supported in HF Hub: parquet, arrow, json, csv, txt | Will read the whole dataset into memory, works for small dataset |
-| tfrecord | local/Cloud Storage | tfrecord | data are not loaded in memory but streamed from the saved location, good for big dataset |
+| tfrecord | local/Cloud Storage | TFRecord | data are not loaded in memory but streamed from the saved location, good for big dataset |
+| Grain | local/Cloud Storage | ArrayRecord (or any random access format) | data are not loaded in memory but streamed from the saved location, good for big dataset, supports global shuffle and data iterator checkpoint for determinism (see details in [doc](https://github.com/AI-Hypercomputer/maxtext/blob/main/getting_started/Data_Input_Pipeline.md#grain-pipeline---for-determinism)) |
 
 ## Usage examples
 
@@ -43,6 +44,12 @@ cache_latents_text_encoder_outputs: True
 ```
 dataset_type: tfrecord
 train_data_dir: gs://<bucket>/<folder>  # will use all TFRecord files under the directory
+```
+
+### Grain (dataset_type=grain)
+```
+dataset_type: grain
+grain_train_files: gs://<bucket>/<folder>/*.arrayrecord  # match the file pattern
 ```
 
 ## Best Practice

--- a/src/maxdiffusion/checkpointing/checkpointing_utils.py
+++ b/src/maxdiffusion/checkpointing/checkpointing_utils.py
@@ -40,6 +40,7 @@ def create_orbax_checkpoint_manager(
     enable_checkpointing: bool,
     save_interval_steps,
     checkpoint_type: str,
+    dataset_type: str = "tf",
     use_async: bool = True,
     orbax_logger: Optional[abstract_logger.AbstractLogger] = None,
 ):
@@ -70,6 +71,8 @@ def create_orbax_checkpoint_manager(
         "text_encoder_2_state",
         "text_encoder_2_config",
     )
+  if dataset_type == "grain":
+    item_names += ("iter",)
 
   print("item_names: ", item_names)
 

--- a/src/maxdiffusion/trainers/base_stable_diffusion_trainer.py
+++ b/src/maxdiffusion/trainers/base_stable_diffusion_trainer.py
@@ -128,6 +128,8 @@ class BaseStableDiffusionTrainer(BaseStableDiffusionCheckpointer):
 
     # Load dataset
     data_iterator = self.load_dataset(pipeline, params, train_states)
+    if self.config.dataset_type == "grain":
+      data_iterator = self.restore_data_iterator_state(data_iterator)
 
     data_shardings = self.get_data_shardings()
     # Compile train_step


### PR DESCRIPTION
Grain data input pipeline is already supported in this previous PR: https://github.com/AI-Hypercomputer/maxdiffusion/pull/130
This PR added ckpt support, so that there is an additional "iter" folder in the ckpt for data iterator to recover the data order resume from the last used index.