### PR TITLE
Unit test fix

### DIFF
--- a/src/maxdiffusion/generate_sdxl.py
+++ b/src/maxdiffusion/generate_sdxl.py
@@ -305,9 +305,7 @@ def run(config):
     _ = [stack.enter_context(nn.intercept_methods(interceptor)) for interceptor in lora_interceptors]
     images = p_run_inference(states).block_until_ready()
   print("inference time: ", (time.time() - s))
-  images = jax.experimental.multihost_utils.process_allgather(images)
-  if len(images.shape) == 5:
-    images = jnp.squeeze(images)
+  images = jax.experimental.multihost_utils.process_allgather(images, tiled=True)
   numpy_images = np.array(images)
   images = VaeImageProcessor.numpy_to_pil(numpy_images)
   for i, image in enumerate(images):

--- a/src/maxdiffusion/generate_sdxl.py
+++ b/src/maxdiffusion/generate_sdxl.py
@@ -306,6 +306,8 @@ def run(config):
     images = p_run_inference(states).block_until_ready()
   print("inference time: ", (time.time() - s))
   images = jax.experimental.multihost_utils.process_allgather(images)
+  if len(images.shape) == 5:
+    images = jnp.squeeze(images)
   numpy_images = np.array(images)
   images = VaeImageProcessor.numpy_to_pil(numpy_images)
   for i, image in enumerate(images):

--- a/tests/schedulers/test_scheduler_flax.py
+++ b/tests/schedulers/test_scheduler_flax.py
@@ -335,8 +335,8 @@ class FlaxDDPMSchedulerTest(FlaxSchedulerCommonTest):
         result_mean = jnp.mean(jnp.abs(sample))
 
         if jax_device == "tpu":
-            assert abs(result_sum - 251.26245) < 1e-2
-            assert abs(result_mean - 0.32716465) < 1e-3
+            assert abs(result_sum - 257.2727) < 1e-2
+            assert abs(result_mean - 0.3349905) < 1e-3
         else:
             assert abs(result_sum - 255.1113) < 1e-2
             assert abs(result_mean - 0.332176) < 1e-3


### PR DESCRIPTION
- Updates jax.experimental.multihost_utils.process_allgather due to new behavior of jax 0.5.0
- Updates numerics for scheduler tests due to jax 0.5.0 new changes on random number generation. See https://github.com/jax-ml/jax/discussions/18480