### PR TITLE
Remove the transformer engine from setup script 

### DIFF
--- a/docs/getting_started/first_run.md
+++ b/docs/getting_started/first_run.md
@@ -12,7 +12,11 @@ multiple hosts.
 1. Clone MaxDiffusion in your TPU VM.
 1. Within the root directory of the MaxDiffusion `git` repo, install dependencies by running:
 ```bash
-bash setup.sh MODE=stable
+If you are running on TPU:
+bash setup.sh MODE=stable DEVICE=tpu
+
+If you are running on GPU:
+bash setup.sh MODE=stable DEVICE=gpu
 ```
 
 ## Getting Starting: Multihost development

--- a/setup.sh
+++ b/setup.sh
@@ -58,7 +58,7 @@ fi
 # Install JAX and JAXlib based on the specified mode
 if [[ "$MODE" == "stable" || ! -v MODE ]]; then
   # Stable mode
-  if [[ $DEVICE == "tpu" ]]; then 
+  if [[ $DEVICE == "tpu" ]]; then
     echo "Installing stable jax, jaxlib for tpu"
     if [[ -n "$JAX_VERSION" ]]; then
       echo "Installing stable jax, jaxlib, libtpu version ${JAX_VERSION}"
@@ -77,8 +77,6 @@ if [[ "$MODE" == "stable" || ! -v MODE ]]; then
         echo "Installing stable jax, jaxlib, libtpu for NVIDIA gpu"
         pip3 install "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
     fi
-    export NVTE_FRAMEWORK=jax
-    pip3 install git+https://github.com/NVIDIA/TransformerEngine.git@stable
   fi
 
 elif [[ $MODE == "nightly" ]]; then
@@ -87,17 +85,14 @@ elif [[ $MODE == "nightly" ]]; then
       echo "Installing jax-nightly, jaxlib-nightly"
       # Install jax-nightly
       pip install -U --pre jax jaxlib jax-cuda12-plugin[with_cuda] jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
-      # Install Transformer Engine
-      export NVTE_FRAMEWORK=jax
-      pip3 install git+https://github.com/NVIDIA/TransformerEngine.git@stable
-  elif [[ $DEVICE == "tpu" ]]; then 
+  elif [[ $DEVICE == "tpu" ]]; then
     echo "Installing jax-nightly,jaxlib-nightly"
     # Install jax-nightly
     pip3 install --pre -U jax -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
     # Install jaxlib-nightly
     pip3 install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
     # Install libtpu-nightly
-    pip3 install --pre -U libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html 
+    pip3 install --pre -U libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   fi
   echo "Installing nightly tensorboard plugin profile"
   pip3 install tbp-nightly --upgrade
@@ -107,7 +102,7 @@ else
 fi
 
 # Install dependencies from requirements.txt
-pip3 install -U -r requirements.txt
+pip3 install -U -r requirements.txt || echo "Failed to install dependencies in the requirements" >&2
 
 # Install maxdiffusion
-pip3 install -U .
+pip3 install -U . || echo "Failed to install maxdiffusion" >&2


### PR DESCRIPTION
The TransformerEngine is not required and it slows down the setup a lot. Removed and updated the read me. Also added error message if the installation fails for the last 2 steps.