### PR TITLE
rollback device put error/regression in unet state and text encoder 2 state and update orbax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ tensorflow-datasets>=4.9.6
 ruff>=0.1.5,<=0.2
 git+https://github.com/mlperf/logging.git
 opencv-python-headless==4.10.0.84
-orbax-checkpoint==0.10.2
+orbax-checkpoint==0.10.3
 tokenizers==0.21.0
 huggingface_hub==0.24.7
 transformers==4.48.1

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -14,7 +14,7 @@ jaxlib>=0.4.30
 Jinja2
 opencv-python-headless==4.10.0.84
 optax>=0.2.3
-orbax-checkpoint==0.10.2
+orbax-checkpoint==0.10.3
 parameterized
 Pillow
 pyink


### PR DESCRIPTION
This pr fixes e2e test failure
1. Device put error in create unet state and create text 2 encoder state by 
2. Orbax and jax incompatibility, jax removed 'enable_memories' in 0.5.0+, orbax removed usage 0.10.3 onwards.
Successful e2e test DAG run, 
![image](https://github.com/user-attachments/assets/76222a28-d159-4775-827c-9e73dbf4fff6)