### PR TITLE
Fix 413751357 updating version of depdendency which is lowering the JAX version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,12 +19,12 @@ Pillow
 pylint
 pyink
 pytest==8.2.2
-tensorflow==2.17.0
+tensorflow>=2.17.0
 tensorflow-datasets>=4.9.6
 ruff>=0.1.5,<=0.2
 git+https://github.com/mlperf/logging.git
 opencv-python-headless==4.10.0.84
-orbax-checkpoint>=0.10.3
+orbax-checkpoint==0.10.3
 tokenizers==0.21.0
 huggingface_hub==0.30.2
 transformers==4.48.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ tensorflow-datasets>=4.9.6
 ruff>=0.1.5,<=0.2
 git+https://github.com/mlperf/logging.git
 opencv-python-headless==4.10.0.84
-orbax-checkpoint==0.10.3
+orbax-checkpoint>=0.10.3
 tokenizers==0.21.0
 huggingface_hub==0.30.2
 transformers==4.48.1

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -14,7 +14,7 @@ jaxlib>=0.4.30
 Jinja2
 opencv-python-headless==4.10.0.84
 optax>=0.2.3
-orbax-checkpoint==0.10.3
+orbax-checkpoint>=0.10.3
 parameterized
 Pillow
 pyink

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -14,7 +14,7 @@ jaxlib>=0.4.30
 Jinja2
 opencv-python-headless==4.10.0.84
 optax>=0.2.3
-orbax-checkpoint>=0.10.3
+orbax-checkpoint==0.10.3
 parameterized
 Pillow
 pyink


### PR DESCRIPTION
Relaxed the condition or tensorflow dependency while still maintaining the minimum requirement

Issue: 
 
```
  Attempting uninstall: jaxlib
    Found existing installation: jaxlib 0.6.1.dev20250425
    Uninstalling jaxlib-0.6.1.dev20250425:
      Successfully uninstalled jaxlib-0.6.1.dev20250425```
```