### PR TITLE
Bug fixes and performance optimizations for FLUX training

### DIFF
--- a/src/maxdiffusion/checkpointing/flux_checkpointer.py
+++ b/src/maxdiffusion/checkpointing/flux_checkpointer.py
@@ -194,7 +194,7 @@ class FluxCheckpointer(ABC):
       clip_tokenizer = CLIPTokenizer.from_pretrained(self.config.clip_model_name_or_path, max_length=77, use_fast=True)
       t5_encoder = FlaxT5EncoderModel.from_pretrained(self.config.t5xxl_model_name_or_path, dtype=self.config.weights_dtype)
       t5_tokenizer = AutoTokenizer.from_pretrained(
-          self.config.t5xxl_model_name_or_path, max_length=self.config.max_sequence_length, use_fast=True
+          self.config.t5xxl_model_name_or_path, model_max_length=self.config.max_sequence_length, use_fast=True
       )
 
       vae, vae_params = FlaxAutoencoderKL.from_pretrained(
@@ -263,7 +263,7 @@ class FluxCheckpointer(ABC):
             self.config.t5xxl_model_name_or_path, dtype=self.config.weights_dtype
         )
         t5_tokenizer = AutoTokenizer.from_pretrained(
-            self.config.t5xxl_model_name_or_path, max_length=self.config.max_sequence_length, use_fast=True
+            self.config.t5xxl_model_name_or_path, model_max_length=self.config.max_sequence_length, use_fast=True
         )
 
         vae = FlaxAutoencoderKL.from_config(

--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -26,7 +26,6 @@ import yaml
 import os
 from pathlib import Path
 import subprocess
-from ctypes import cdll
 import numpy as np
 
 import flax
@@ -63,8 +62,6 @@ from tensorboardX import writer
 
 from google.cloud import storage
 
-libcudart = cdll.LoadLibrary("libcudart.so")
-
 FrozenDict = core.frozen_dict.FrozenDict
 
 
@@ -81,18 +78,12 @@ def l2norm_pytree(x):
 
 def activate_profiler(config):
   if jax.process_index() == 0 and config.enable_profiler:
-    if config.profiler == 'nsys':
-      libcudart.cudaProfilerStart()
-    else:
-      jax.profiler.start_trace(config.tensorboard_dir)
+    jax.profiler.start_trace(config.tensorboard_dir)
 
 
 def deactivate_profiler(config):
   if jax.process_index() == 0 and config.enable_profiler:
-    if config.profiler == 'nsys':
-      libcudart.cudaProfilerStop()
-    else:
-      jax.profiler.stop_trace()
+    jax.profiler.stop_trace()
 
 
 def initialize_summary_writer(config):


### PR DESCRIPTION
Bug fixes:
1. Fix the text sequence length configuration issue
2. Fix the race condition when clean up the encoder cache in multi-process run

Performance optimizations:
1. Fix the FSDP sharding in fc2
2. Remove sharding of the bias to avoid all-gather
3. Remove the sharding of rope embedding to avoid all-gather
4. Fix the sharding of time step embedding to avoid all-to-all

Also added nsys profiler support
