### PR TITLE
[DO Not Merge] Test Pin pytest version to 8.2.2

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tpu-type: ["v4-8"]
+        tpu-type: ["v5-8"]
     name: "TPU test (${{ matrix.tpu-type }})"
     runs-on: ["self-hosted", "tpu", "${{ matrix.tpu-type }}"]
     steps:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -48,7 +48,7 @@ jobs:
         export PATH=$PATH:$HOME/.local/bin
         pip install ruff
         pip install isort
-        pip install pytest
+        pip install pytest==8.2.2
     - name: Analysing the code with ruff
       run: |
         ruff check .


### PR DESCRIPTION
Runner is failing to run tests. Previously we have seen successful test runs with python 3.12 + jax 0.7.0.

Trying to see if pinning the pytest version fixes the issue.