### PR TITLE
support generating video for eval

### DIFF
--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -298,3 +298,4 @@ quantization_calibration_method: "absmax"
 # Eval model on per eval_every steps. -1 means don't eval.
 eval_every: -1
 eval_data_dir: ""
+enable_generate_video_for_eval: False # This will increase the used TPU memory.

--- a/src/maxdiffusion/generate_wan.py
+++ b/src/maxdiffusion/generate_wan.py
@@ -15,13 +15,86 @@
 from typing import Sequence
 import jax
 import time
+import os
 from maxdiffusion.pipelines.wan.wan_pipeline import WanPipeline
 from maxdiffusion import pyconfig, max_logging, max_utils
 from absl import app
 from maxdiffusion.utils import export_to_video
+from google.cloud import storage
+
+def upload_video_to_gcs(output_dir: str, video_path: str):
+    """
+    Uploads a local video file to a specified Google Cloud Storage bucket.
+    """
+    try:
+        path_without_scheme = output_dir.removeprefix("gs://")
+        parts = path_without_scheme.split('/', 1)
+        bucket_name = parts[0]
+        folder_name = parts[1] if len(parts) > 1 else ''
+
+        # Initialize the GCS client
+        storage_client = storage.Client()
+
+        # Get the bucket object
+        bucket = storage_client.bucket(bucket_name)
+
+        # Define the source and destination paths
+        source_file_path = f"./{video_path}"
+        destination_blob_name = os.path.join(folder_name, "videos", video_path)
+
+        # Create a blob object
+        blob = bucket.blob(destination_blob_name)
+
+        # Upload the file
+        max_logging.log(f"Uploading {source_file_path} to {bucket_name}/{destination_blob_name}...")
+        blob.upload_from_filename(source_file_path)
+        max_logging.log(f"Upload complete {source_file_path}.")
+
+    except Exception as e:
+        max_logging.log(f"An error occurred: {e}")
+
+def delete_file(file_path: str):
+   # Best practice: Check if the file exists before trying to delete it.
+  if os.path.exists(file_path):
+      try:
+          os.remove(file_path)
+          max_logging.log(f"Successfully deleted file: {file_path}")
+      except OSError as e:
+          # This catches other issues like permission errors
+          max_logging.log(f"Error deleting file '{file_path}': {e}")
+  else:
+      max_logging.log(f"The file '{file_path}' does not exist.")
 
 jax.config.update("jax_use_shardy_partitioner", True)
 
+def inference_generate_video(config, pipeline, filename_prefix=""):
+  s0 = time.perf_counter()
+  prompt = [config.prompt] * config.global_batch_size_to_train_on
+  negative_prompt = [config.negative_prompt] * config.global_batch_size_to_train_on
+
+  max_logging.log(
+      f"Num steps: {config.num_inference_steps}, height: {config.height}, width: {config.width}, frames: {config.num_frames}, video: {filename_prefix}"
+  )
+
+  videos = pipeline(
+      prompt=prompt,
+      negative_prompt=negative_prompt,
+      height=config.height,
+      width=config.width,
+      num_frames=config.num_frames,
+      num_inference_steps=config.num_inference_steps,
+      guidance_scale=config.guidance_scale,
+  )
+
+  max_logging.log(f"video {filename_prefix}, compile time: {(time.perf_counter() - s0)}")
+  for i in range(len(videos)):
+    video_path = f"{filename_prefix}wan_output_{config.seed}_{i}.mp4"
+    export_to_video(videos[i], video_path, fps=config.fps)
+    if config.output_dir.startswith("gs://"):
+      upload_video_to_gcs(config.output_dir, video_path)
+      # Delete local files to avoid storing too manys videoss
+      delete_file(f"./{video_path}")
+  return
 
 def run(config, pipeline=None, filename_prefix=""):
   print("seed: ", config.seed)
@@ -57,6 +130,8 @@ def run(config, pipeline=None, filename_prefix=""):
     video_path = f"{filename_prefix}wan_output_{config.seed}_{i}.mp4"
     export_to_video(videos[i], video_path, fps=config.fps)
     saved_video_path.append(video_path)
+    if config.output_dir.startswith("gs://"):
+      upload_video_to_gcs(config.output_dir, video_path)
 
   s0 = time.perf_counter()
   videos = pipeline(

--- a/src/maxdiffusion/generate_wan.py
+++ b/src/maxdiffusion/generate_wan.py
@@ -32,20 +32,14 @@ def upload_video_to_gcs(output_dir: str, video_path: str):
         bucket_name = parts[0]
         folder_name = parts[1] if len(parts) > 1 else ''
 
-        # Initialize the GCS client
         storage_client = storage.Client()
-
-        # Get the bucket object
         bucket = storage_client.bucket(bucket_name)
 
-        # Define the source and destination paths
         source_file_path = f"./{video_path}"
         destination_blob_name = os.path.join(folder_name, "videos", video_path)
 
-        # Create a blob object
         blob = bucket.blob(destination_blob_name)
 
-        # Upload the file
         max_logging.log(f"Uploading {source_file_path} to {bucket_name}/{destination_blob_name}...")
         blob.upload_from_filename(source_file_path)
         max_logging.log(f"Upload complete {source_file_path}.")
@@ -54,13 +48,11 @@ def upload_video_to_gcs(output_dir: str, video_path: str):
         max_logging.log(f"An error occurred: {e}")
 
 def delete_file(file_path: str):
-   # Best practice: Check if the file exists before trying to delete it.
   if os.path.exists(file_path):
       try:
           os.remove(file_path)
           max_logging.log(f"Successfully deleted file: {file_path}")
       except OSError as e:
-          # This catches other issues like permission errors
           max_logging.log(f"Error deleting file '{file_path}': {e}")
   else:
       max_logging.log(f"The file '{file_path}' does not exist.")
@@ -92,7 +84,7 @@ def inference_generate_video(config, pipeline, filename_prefix=""):
     export_to_video(videos[i], video_path, fps=config.fps)
     if config.output_dir.startswith("gs://"):
       upload_video_to_gcs(config.output_dir, video_path)
-      # Delete local files to avoid storing too manys videoss
+      # Delete local files to avoid storing too manys videos
       delete_file(f"./{video_path}")
   return
 


### PR DESCRIPTION
Add parameter:

enable_generate_video_for_eval

When it is True and eval_every > 0, WAN generate the video with the trained model every eval_every steps.

If the output_dir is in gs, the generated videos are uploaded to gs and local videos are deleted.