### PR TITLE
Fix for XLML tests failing with jax nightly

### DIFF
--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -359,12 +359,11 @@ def get_abstract_state(model, tx, config, mesh, weights_init_fn, training=True):
   state_mesh_shardings = nn.logical_to_mesh_sharding(state_logical_annotations, mesh, config.logical_axis_rules)
 
   abstract_sharded_state = jax.jit(init_state_partial, in_shardings=None, out_shardings=state_mesh_shardings).eval_shape()
-  unboxed_sharded_abstract_state = unbox_logicallypartioned_trainstate(abstract_sharded_state)
 
   # Initialization
   with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
     state_mesh_annotations = nn.logical_to_mesh(state_logical_annotations)
-  return unboxed_sharded_abstract_state, state_mesh_annotations, state_mesh_shardings
+  return abstract_sharded_state, state_mesh_annotations, state_mesh_shardings
 
 
 def setup_initial_state(


### PR DESCRIPTION
Nightly XLML tests have been failing with this message: 

`jax._src.dtypes.InvalidInputException: Argument 'ShapeDtypeStruct(...)' of type <class 'jax._src.core.ShapeDtypeStruct'> is not a valid JAX type.`

These are the logs: https://paste.googleplex.com/4875429911199744

There is a call to x.unbox() within unbox_logicallypartioned_trainstate during the setup_initial_state. The code is doing sharding on an abstract representation of an array, which jax doesn't allow. The fix is to only do the unboxing on concrete arrays and not abstract arrays.

Link to successfull workload run after the change: https://c3aed121fd4247389a3ca4b9c5878779-dot-us-east4.composer.googleusercontent.com/dags/jax_ai_image_candidate_tpu_e2e/grid?tab=graph&dag_run_id=manual__2025-09-05T10%3A19%3A29.084042%2B00%3A00&task_id=maxdiffusion-jax-stable-stack-sdxl-stable-v5-8-1x-v5p-8