### PR TITLE
[WAN] Use different sharding strategy for self and cross attention.

### DIFF
--- a/src/maxdiffusion/models/wan/transformers/transformer_wan.py
+++ b/src/maxdiffusion/models/wan/transformers/transformer_wan.py
@@ -282,6 +282,7 @@ class WanTransformerBlock(nnx.Module):
         precision=precision,
         attention_kernel=attention,
         dropout=dropout,
+        is_self_attention=True,
     )
 
     # 1. Cross-attention
@@ -300,6 +301,7 @@ class WanTransformerBlock(nnx.Module):
         precision=precision,
         attention_kernel=attention,
         dropout=dropout,
+        is_self_attention=False,
     )
     assert cross_attn_norm is True
     self.norm2 = FP32LayerNorm(rngs=rngs, dim=dim, eps=eps, elementwise_affine=True)


### PR DESCRIPTION
Benchmark results on v6e-8:

480p video generation (81 frames)
* Baseline (main 3cd6a443d0d0ea8ec35f82c2bee29843f5c4b54e): 78s
* This PR: 66s (15% improvement)

720p video generation (81 frames)
* Baseline (main 3cd6a443d0d0ea8ec35f82c2bee29843f5c4b54e): 215s
* This PR: 200s (7% improvement)

---

Benchmark command used:
480p:
```
HF_HUB_DISABLE_XET=True HF_HUB_CACHE=/mnt/disks/external_disk/maxdiffusion_hf_cache/ HF_TOKEN=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 LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_reduce=true" HF_HUB_ENABLE_HF_TRANSFER=1 python src/maxdiffusion/generate_wan.py src/maxdiffusion/configs/base_wan_14b.yml attention="splash_wan" num_inference_steps=30 num_frames=81 width=832 height=480 jax_cache_dir=/tmp/jax_cache/ per_device_batch_size=.125 ici_data_parallelism=2 ici_fsdp_parallelism=4 enable_profiler=False run_name=wan-inference-testing output_dir=/tmp/ fps=16 flash_block_sizes='{"block_q" : 3024, "block_kv_compute" : 1024, "block_kv" : 2048, "block_q_dkv": 3024, "block_kv_dkv" : 2048, "block_kv_dkv_compute" : 2048, "block_q_dq" : 3024, "block_kv_dq" : 2048 }'
```
720p:
```
HF_HUB_DISABLE_XET=True \
HF_HUB_CACHE=/mnt/disks/external_disk/maxdiffusion_hf_cache/ \
HF_TOKEN=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 \
LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_reduce=true" \
HF_HUB_ENABLE_HF_TRANSFER=1 \
python src/maxdiffusion/generate_wan.py \
  src/maxdiffusion/configs/base_wan_14b.yml \
  attention="flash" \
  num_inference_steps=30 \
  num_frames=81 \
  width=1280 \
  height=720 \
  jax_cache_dir=/tmp/jax_cache/ \
  per_device_batch_size=.125 \
  ici_data_parallelism=2 \
  ici_fsdp_parallelism=4 \
  flow_shift=5.0 \
  enable_profiler=False \
  run_name=wan-inference-testing-720p \
  output_dir=/tmp/ \
  fps=16 \
  flash_block_sizes='{"block_q" : 3024, "block_kv_compute" : 1024, "block_kv" : 2048, "block_q_dkv": 3024, "block_kv_dkv" : 2048, "block_kv_dkv_compute" : 2048, "block_q_dq" : 3024, "block_kv_dq" : 2048 }'
```