### PR TITLE
Update entrypoint for jaii image builds

### DIFF
--- a/maxdiffusion_jax_ai_image_tpu.Dockerfile
+++ b/maxdiffusion_jax_ai_image_tpu.Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 RUN pip install -r /deps/requirements_with_jax_ai_image.txt
 
 # Run the script available in JAX-AI-Image base image to generate the manifest file
-RUN bash /jax-stable-stack/generate_manifest.sh PREFIX=maxdiffusion COMMIT_HASH=$COMMIT_HASH
+RUN bash /jax-ai-image/generate_manifest.sh PREFIX=maxdiffusion COMMIT_HASH=$COMMIT_HASH


### PR DESCRIPTION
JAX AI Images will now use jax-ai-image as entrypoint as opposed to jax-stable-stack, which is the old naming convention. We need to update the entrypoint here as well for our daily image builds for XLML tests.