### PR TITLE
New Eval Pipeline as the MLPerf

### DIFF
--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -318,6 +318,6 @@ quantization_calibration_method: "absmax"
 eval_every: -1
 eval_data_dir: ""
 enable_generate_video_for_eval: False # This will increase the used TPU memory.
-eval_max_number_of_samples_in_bucket: 60
+eval_max_number_of_samples_in_bucket: 60 # The number of samples per bucket for evaluation. This is calculated by num_eval_samples / len(considered_timesteps_list).
 
 enable_ssim: True

--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -319,4 +319,3 @@ eval_every: -1
 eval_data_dir: ""
 enable_generate_video_for_eval: False # This will increase the used TPU memory.
 eval_max_number_of_samples_in_bucket: 60
-eval_max_processed_batch_size: 8 # This is the max batch size per device for eval step. If the global eval batch size is larger than this, the eval step will be run multiple times.

--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -319,3 +319,4 @@ eval_every: -1
 eval_data_dir: ""
 enable_generate_video_for_eval: False # This will increase the used TPU memory.
 eval_max_number_of_samples_in_bucket: 60
+eval_max_processed_batch_size: 8 # This is the max batch size per device for eval step. If the global eval batch size is larger than this, the eval step will be run multiple times.

--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -235,6 +235,8 @@ global_batch_size: 0
 tfrecords_dir: ''
 no_records_per_shard: 0
 enable_eval_timesteps: False
+considered_timesteps_list: [125, 250, 375, 500, 625, 750, 875]
+num_eval_samples: 420
 
 warmup_steps_fraction: 0.1
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
@@ -316,3 +318,4 @@ quantization_calibration_method: "absmax"
 eval_every: -1
 eval_data_dir: ""
 enable_generate_video_for_eval: False # This will increase the used TPU memory.
+eval_max_number_of_samples_in_bucket: 60

--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -319,3 +319,5 @@ eval_every: -1
 eval_data_dir: ""
 enable_generate_video_for_eval: False # This will increase the used TPU memory.
 eval_max_number_of_samples_in_bucket: 60
+
+enable_ssim: True

--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -234,6 +234,7 @@ global_batch_size: 0
 # For creating tfrecords from dataset
 tfrecords_dir: ''
 no_records_per_shard: 0
+enable_eval_timesteps: False
 
 warmup_steps_fraction: 0.1
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.

--- a/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
+++ b/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
@@ -85,9 +85,10 @@ def generate_dataset(config):
   shard_record_count = 0
 
   # Define timesteps and bucket configuration
-  timesteps_list = [125, 250, 375, 500, 625, 750, 875]
-  bucket_size = 60
-  num_samples_to_process = 420
+  num_eval_samples = config.num_eval_samples
+  timesteps_list = config.timesteps_list
+  assert num_eval_samples % len(timesteps_list) == 0
+  bucket_size = num_eval_samples // len(timesteps_list)
 
   # Load dataset
   metadata_path = os.path.join(config.train_data_dir, "metadata.csv")
@@ -115,12 +116,12 @@ def generate_dataset(config):
       current_timestep = None
       # Determine the timestep for the first 420 samples
       if config.enable_eval_timesteps:
-        if global_record_count < num_samples_to_process:
+        if global_record_count < num_eval_samples:
           print(f"global_record_count: {global_record_count}")
           bucket_index = global_record_count // bucket_size
           current_timestep = timesteps_list[bucket_index]
         else:
-          print(f"value {global_record_count} is greater than or equal to {num_samples_to_process}")
+          print(f"value {global_record_count} is greater than or equal to {num_eval_samples}")
           return
 
       # Write the example, including the timestep if applicable

--- a/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
+++ b/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
@@ -55,13 +55,17 @@ def float_feature_list(value):
   return tf.train.Feature(float_list=tf.train.FloatList(value=value))
 
 
-def create_example(latent, hidden_states):
+def create_example(latent, hidden_states, timestep=None):
   latent = tf.io.serialize_tensor(latent)
   hidden_states = tf.io.serialize_tensor(hidden_states)
   feature = {
       "latents": bytes_feature(latent),
       "encoder_hidden_states": bytes_feature(hidden_states),
   }
+  # Add timestep feature if it is provided
+  if timestep is not None:
+    feature["timesteps"] = int64_feature(timestep)
+
   example = tf.train.Example(features=tf.train.Features(feature=feature))
   return example.SerializeToString()
 
@@ -79,6 +83,11 @@ def generate_dataset(config):
       tfrecords_dir + "/file_%.2i-%i.tfrec" % (tf_rec_num, (global_record_count + no_records_per_shard))
   )
   shard_record_count = 0
+
+  # Define timesteps and bucket configuration
+  timesteps_list = [125, 250, 375, 500, 625, 750, 875]
+  bucket_size = 60
+  num_samples_to_process = 420
 
   # Load dataset
   metadata_path = os.path.join(config.train_data_dir, "metadata.csv")
@@ -102,7 +111,18 @@ def generate_dataset(config):
       # Save them as float32 because numpy cannot read bfloat16.
       latent = jnp.array(latent.float().numpy(), dtype=jnp.float32)
       prompt_embeds = jnp.array(prompt_embeds.float().numpy(), dtype=jnp.float32)
-      writer.write(create_example(latent, prompt_embeds))
+
+      # Determine the timestep for the first 420 samples
+      current_timestep = None
+      if global_record_count < num_samples_to_process:
+        bucket_index = global_record_count // bucket_size
+        current_timestep = timesteps_list[bucket_index]
+      else:
+        print(f"value {global_record_count} is greater than or equal to {num_samples_to_process}")
+        return
+
+      # Write the example, including the timestep if applicable
+      writer.write(create_example(latent, prompt_embeds, timestep=current_timestep))
       shard_record_count += 1
       global_record_count += 1
 

--- a/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
+++ b/src/maxdiffusion/data_preprocessing/wan_pusav1_to_tfrecords.py
@@ -112,14 +112,16 @@ def generate_dataset(config):
       latent = jnp.array(latent.float().numpy(), dtype=jnp.float32)
       prompt_embeds = jnp.array(prompt_embeds.float().numpy(), dtype=jnp.float32)
 
-      # Determine the timestep for the first 420 samples
       current_timestep = None
-      if global_record_count < num_samples_to_process:
-        bucket_index = global_record_count // bucket_size
-        current_timestep = timesteps_list[bucket_index]
-      else:
-        print(f"value {global_record_count} is greater than or equal to {num_samples_to_process}")
-        return
+      # Determine the timestep for the first 420 samples
+      if config.enable_eval_timesteps:
+        if global_record_count < num_samples_to_process:
+          print(f"global_record_count: {global_record_count}")
+          bucket_index = global_record_count // bucket_size
+          current_timestep = timesteps_list[bucket_index]
+        else:
+          print(f"value {global_record_count} is greater than or equal to {num_samples_to_process}")
+          return
 
       # Write the example, including the timestep if applicable
       writer.write(create_example(latent, prompt_embeds, timestep=current_timestep))

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -472,6 +472,7 @@ def eval_step(state, data, rng, scheduler_state, scheduler, config):
   # --- Key Difference from train_step ---
   # Directly compute the loss without calculating gradients.
   # The model's state.params are used but not updated.
+  # TODO(coolkp): Explore optimizing the creation of PRNGs in a vmap or statically outside of the loop
   bs = len(data["latents"])
   single_batch_size = config.global_batch_size_to_train_on
   losses = jnp.zeros(bs)

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -233,7 +233,7 @@ class WanTrainer(WanCheckpointer):
     if self.config.enable_ssim:
       posttrained_video_path = generate_sample(self.config, pipeline, filename_prefix="post-training-")
       print_ssim(pretrained_video_path, posttrained_video_path)
-  
+
   def eval(self, mesh, eval_rng_key, step, p_eval_step, state, scheduler_state, writer):
     eval_data_iterator = self.load_dataset(mesh, is_training=False)
     eval_rng = eval_rng_key

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -480,4 +480,4 @@ def eval_step(state, data, rng, scheduler_state, scheduler, config):
   metrics = {"scalar": {"learning/eval_loss": loss}}
 
   # Return the computed metrics and the new RNG key for the next eval step
-  return metrics, new_rng, 
+  return metrics, new_rng

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -336,7 +336,6 @@ class WanTrainer(WanCheckpointer):
                   if timestep not in eval_losses_by_timestep:
                       eval_losses_by_timestep[timestep] = []
                   eval_losses_by_timestep[timestep].append(l)
-                  print(f"timesteps: {timestep}, losses: {l}")
             except StopIteration:
               # This block is executed when the iterator has no more data
               break

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -345,7 +345,7 @@ class WanTrainer(WanCheckpointer):
             max_logging.log(f"Step {step}, calculating mean loss per timestep...")
             for timestep, losses in sorted(eval_losses_by_timestep.items()):
                 losses = jnp.array(losses)
-                losses = losses[: min(60, len(losses))]
+                losses = losses[: min(self.config.eval_max_number_of_samples_in_bucket, len(losses))]
                 mean_loss = jnp.mean(losses)
                 max_logging.log(f"  Mean eval loss for timestep {timestep}: {mean_loss:.4f}, num of losses: {len(losses)}")
                 mean_per_timestep.append(mean_loss)

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -333,10 +333,9 @@ class WanTrainer(WanCheckpointer):
                   self.config.logical_axis_rules
               ):
                 metrics, eval_rng = p_eval_step(state, eval_batch, eval_rng, scheduler_state)
+                metrics["scalar"]["learning/eval_loss"].block_until_ready()
               losses = metrics["scalar"]["learning/eval_loss"]
               timesteps = eval_batch["timesteps"]
-              gathered_losses_on_device = multihost_utils.process_allgather(losses)
-              gathered_losses = jax.device_get(gathered_losses_on_device)
               for t, l in zip(timesteps.flatten(), losses.flatten()):
                 timestep = int(t)
                 if timestep not in eval_losses_by_timestep:

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -465,6 +465,7 @@ def eval_step(state, data, rng, scheduler_state, scheduler, config):
     training_weight = jnp.expand_dims(scheduler.training_weight(scheduler_state, timesteps), axis=(1, 2, 3, 4))
     loss = (training_target - model_pred) ** 2
     loss = loss * training_weight
+    # Calculate the mean loss per sample across all non-batch dimensions.
     loss = loss.reshape(loss.shape[0], -1).mean(axis=1)
 
     return loss

--- a/src/maxdiffusion/trainers/wan_trainer.py
+++ b/src/maxdiffusion/trainers/wan_trainer.py
@@ -176,7 +176,6 @@ class WanTrainer(WanCheckpointer):
       raise ValueError(
           "Wan 2.1 training only supports config.dataset_type set to tfrecords and config.cache_latents_text_encoder_outputs set to True"
       )
-    
     feature_description = {
         "latents": tf.io.FixedLenFeature([], tf.string),
         "encoder_hidden_states": tf.io.FixedLenFeature([], tf.string),


### PR DESCRIPTION
- Implement the new eval pipeline which matches that in MLPerf.


      ALGORITHM: Validation Loss Computation
      
      INPUT:
        - validation_samples: set of validation data samples
      
      INITIALIZE:
        - sum[8]: array of zeros for accumulating losses
        - count[8]: array of zeros for counting samples per timestep
      
      FOR each sample, timestep in validation_samples:
          loss = forward_pass(sample, timestep=t/8)
          sum[t] += loss
          count[t] += 1
      
      mean_per_timestep = sum / count
      validation_loss = mean(mean_per_timestep)
      
      RETURN validation_loss

- Add new para enable_ssim which help to debug.