### PR TITLE
Fix WAN training/inference error for new JAX/Flax Version

### DIFF
--- a/src/maxdiffusion/generate_wan.py
+++ b/src/maxdiffusion/generate_wan.py
@@ -21,6 +21,7 @@ from maxdiffusion import pyconfig, max_logging, max_utils
 from absl import app
 from maxdiffusion.utils import export_to_video
 from google.cloud import storage
+import flax
 
 
 def upload_video_to_gcs(output_dir: str, video_path: str):
@@ -161,6 +162,7 @@ def run(config, pipeline=None, filename_prefix=""):
 
 def main(argv: Sequence[str]) -> None:
   pyconfig.initialize(argv)
+  flax.config.update('flax_always_shard_variable', False)
   run(pyconfig.config)
 
 

--- a/src/maxdiffusion/train_wan.py
+++ b/src/maxdiffusion/train_wan.py
@@ -20,6 +20,7 @@ import jax
 from absl import app
 from maxdiffusion import max_logging, pyconfig
 from maxdiffusion.train_utils import validate_train_config
+import flax
 
 
 def train(config):
@@ -34,6 +35,7 @@ def main(argv: Sequence[str]) -> None:
   config = pyconfig.config
   validate_train_config(config)
   max_logging.log(f"Found {jax.device_count()} devices.")
+  flax.config.update('flax_always_shard_variable', False)
   train(config)
 
 


### PR DESCRIPTION
The newer version of JAX 0.7.2 and Flax 0.12.0 now strictly requires a mesh to be defined whenever you initialize parameters with sharding rules, even in a single-device unit test environment.

From Flax team, the issue is due to this change: https://github.com/google/flax/blob/main/docs_nnx/flip/4844-var-eager-sharding.md

Simplify the creation of sharded NNX models. When a sharding annotation is provided, all nnx.Variable creation will require a mesh context and automatically be sharded as annotated.

It can be disabled by using flax.config.update('flax_always_shard_variable', False).

In maxDiffusion, only WAN 2.1 use the flax modules.