### PR TITLE
host offloading

### DIFF
--- a/src/maxdiffusion/configs/base_wan_14b.yml
+++ b/src/maxdiffusion/configs/base_wan_14b.yml
@@ -81,7 +81,8 @@ flash_block_sizes: {
 #   "block_kv_dkv" : 2048,
 #   "block_kv_dkv_compute" : 2048,
 #   "block_q_dq" : 3024,
-#   "block_kv_dq" : 2048
+#   "block_kv_dq" : 2048,
+#   "use_fused_bwd_kernel": False,
 # }
 # GroupNorm groups
 norm_num_groups: 32

--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -489,6 +489,11 @@ def get_precision(config):
     retval = jax.lax.Precision.HIGHEST
   return retval
 
+def value_or_none(flash_block_sizes, key):
+  if key in flash_block_sizes:
+    return flash_block_sizes[key]
+  else:
+    return None
 
 def get_flash_block_sizes(config):
   """Create custom flash attention BlockSizes."""
@@ -501,8 +506,9 @@ def get_flash_block_sizes(config):
         block_q_dkv=config.flash_block_sizes["block_q_dkv"],
         block_kv_dkv=config.flash_block_sizes["block_kv_dkv"],
         block_kv_dkv_compute=config.flash_block_sizes["block_kv_dkv_compute"],
-        block_q_dq=config.flash_block_sizes["block_q_dq"],
-        block_kv_dq=config.flash_block_sizes["block_kv_dq"],
+        block_q_dq=value_or_none(config.flash_block_sizes, "block_q_dq"),
+        block_kv_dq=value_or_none(config.flash_block_sizes, "block_kv_dq"),
+        use_fused_bwd_kernel=value_or_none(config.flash_block_sizes, "use_fused_bwd_kernel")
     )
   return flash_block_sizes
 

--- a/src/maxdiffusion/models/gradient_checkpoint.py
+++ b/src/maxdiffusion/models/gradient_checkpoint.py
@@ -41,6 +41,7 @@ class GradientCheckpointType(Enum):
   MATMUL_WITHOUT_BATCH = auto()
   OFFLOAD_MATMUL_WITHOUT_BATCH = auto()
   CUSTOM = auto()
+  HIDDEN_STATE_WITH_OFFLOAD = auto()
 
   @classmethod
   def from_str(cls, s: Optional[str] = None) -> "GradientCheckpointType":
@@ -76,6 +77,13 @@ class GradientCheckpointType(Enum):
             offload_dst="pinned_host",
         )
         return policy
+      case GradientCheckpointType.HIDDEN_STATE_WITH_OFFLOAD:
+        return jax.checkpoint_policies.save_and_offload_only_these_names(
+            names_which_can_be_saved=[],
+            names_which_can_be_offloaded=["hidden_states","self_attn","cross_attn"],
+            offload_src="device",
+            offload_dst="pinned_host",
+        )
       case GradientCheckpointType.MATMUL_WITHOUT_BATCH:
         return jax.checkpoint_policies.checkpoint_dots_with_no_batch_dims
 


### PR DESCRIPTION
Transfer the code mainly on host offloading from g3 to github:

-  b/816371919, Misc fixes to maxdiffusion: 1. Shards the hidden state input to the model 2. Factor in different flash block sizes to estimate the final padding for q/k/v.
- b/817363551, Fix fused splash kernel configuration
- b/817366090, Add remat policy for hidden states and attention activations

Test on v5p-8:
- FULL Remat, Step time 36718.2 ms, Peak Memory 49.37GB
- HIDDEN_STATE_WITH_OFFLOAD Remat, Step time 32776.9 ms, Peak Memory 48.72 GB