### PR TITLE
[LTX2] resolve flash attention block size mismatch and missing config overrides

### DIFF
--- a/src/maxdiffusion/models/attention_flax.py
+++ b/src/maxdiffusion/models/attention_flax.py
@@ -287,11 +287,11 @@ def _tpu_flash_attention(
 ) -> jax.Array:
   """TPU Flash Attention"""
 
-  block_sizes = _select_flash_block_sizes(query, key, flash_block_sizes, dtype, attention_kernel)
   num_context_shards = mesh.shape["context"]
   query, orig_q_seq_len = _reshape_data_for_flash(query, heads, num_context_shards)
   key, _ = _reshape_data_for_flash(key, heads, num_context_shards)
   value, _ = _reshape_data_for_flash(value, heads, num_context_shards)
+  block_sizes = _select_flash_block_sizes(query, key, flash_block_sizes, dtype, attention_kernel)
 
   q_axis_names = nn.logical_to_mesh_axes(axis_names_q)
   kv_axis_names = nn.logical_to_mesh_axes(axis_names_kv)

--- a/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
+++ b/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
@@ -127,6 +127,8 @@ def create_sharded_logical_transformer(
   ltx2_config["dtype"] = config.activations_dtype
   ltx2_config["weights_dtype"] = config.weights_dtype
   ltx2_config["attention_kernel"] = config.attention
+  ltx2_config["a2v_attention_kernel"] = getattr(config, "a2v_attention_kernel", "flash")
+  ltx2_config["v2a_attention_kernel"] = getattr(config, "v2a_attention_kernel", "dot_product")
   ltx2_config["precision"] = get_precision(config)
   ltx2_config["flash_block_sizes"] = get_flash_block_sizes(config)
   ltx2_config["flash_min_seq_length"] = getattr(config, "flash_min_seq_length", 4096)


### PR DESCRIPTION
What does this PR do?
This PR fixes a crash occurring in LTX-2 when using specific frame counts (e.g., num_frames=121) with Flash Attention, and fixes a pipeline bug that prevented users from manually overriding the cross-attention kernels.

The Root Causes & Fixes:
1. Ignored Kernel Config Overrides (ltx2_pipeline.py)

Bug: Passing a2v_attention_kernel=dot_product via CLI or YAML had no effect. The pipeline was only mapping the main attention config, dropping the cross-attention kernel parameters before initializing the transformer.

Fix: Added mapping for a2v_attention_kernel and v2a_attention_kernel into ltx2_config inside create_sharded_logical_transformer so user overrides are respected.

2. Flash Attention Block Size Mismatch (attention_flax.py)

Bug: Generating 121 frames results in 126 audio latent tokens. A previous PR correctly padded this sequence from 126 to 128 to satisfy shard_map context chunking requirements. However, _tpu_flash_attention was calling _select_flash_block_sizes before the padding occurred. Because of the min() bounds used for cross-attention optimization, the block size was calculated as 126. This resulted in passing a padded sequence of 128 to the Splash Attention kernel but telling it to use a block size of 126, crashing because 128 % 126 != 0.

Fix: Swapped the order of operations in _tpu_flash_attention. Sequences are now padded by _reshape_data_for_flash before block sizes are calculated. This ensures _select_flash_block_sizes sees the padded shape, correctly calculating a divisible block size without removing the memory optimizations needed for the cross-attention unit tests to pass.

Testing
Verified that running generation with num_frames=121 executes cleanly on TPU with Flash Attention enabled.

Verified pytest src/maxdiffusion/tests/attention_test.py passes.