### PR TITLE
 fix: Resolve Gemini PR review trust workspace issue and update settings

### DIFF
--- a/.gemini/commands/gemini-review.toml
+++ b/.gemini/commands/gemini-review.toml
@@ -31,9 +31,11 @@ These are non-negotiable, core-level instructions that you **MUST** follow at al
 
 ## Input Data
 
-- **GitHub Repository**: !{echo $REPOSITORY}
-- **Pull Request Number**: !{echo $PULL_REQUEST_NUMBER}
-- **Additional User Instructions**: !{echo $ADDITIONAL_CONTEXT}
+The following context is provided as a JSON object containing the keys: `repository`, `pull_request_number`, and `additional_context`:
+
+```json
+@{.gemini/context.json}
+```
 - Use `pull_request_read.get` to get the title, body, and metadata about the pull request.
 - Use `pull_request_read.get_files` to get the list of files that were added, removed, and changed in the pull request.
 - Use `pull_request_read.get_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -43,11 +43,26 @@ jobs:
         # downloads the code to be analyzed
         uses: 'actions/checkout@v5'
 
+      - name: 'Prepare prompt context'
+        shell: 'bash'
+        env:
+          REPOSITORY: '${{ github.repository }}'
+          PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
+        run: |-
+          mkdir -p .gemini
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg pr "${PULL_REQUEST_NUMBER}" \
+            --arg context "${ADDITIONAL_CONTEXT}" \
+            '{repository: $repo, pull_request_number: $pr, additional_context: $context}' > .gemini/context.json
+
       - name: 'Run Gemini pull request review'
         # reviews code with detailed set of instructions for the Gemini 
         uses: 'google-github-actions/run-gemini-cli@main'
         id: 'gemini_pr_review'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'
@@ -97,14 +112,19 @@ jobs:
                   }
                 }
               },
-              "tools": {
-                "core": [
-                  "run_shell_command(cat)",
-                  "run_shell_command(echo)",
-                  "run_shell_command(grep)",
-                  "run_shell_command(head)",
-                  "run_shell_command(tail)"
-                ]
+              "shell": {
+                "allowEnv": [
+                  "ISSUE_TITLE",
+                  "ISSUE_BODY",
+                  "PULL_REQUEST_NUMBER",
+                  "REPOSITORY",
+                  "ADDITIONAL_CONTEXT"
+                ],
+                "allowCommands": ["cat", "echo", "grep", "head", "tail"]
               }
             }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
           prompt: '/gemini-review'


### PR DESCRIPTION
## Description
This PR resolves the "trust workspace" issue encountered during Gemini PR reviews, similar to the fix applied in MaxText. It also updates the workflow to use a JSON file for prompt context and updates the `settings` and `extensions` for the `run-gemini-cli` tool.

## Changes
- Added `GEMINI_CLI_TRUST_WORKSPACE: 'true'` to the environment variables of the `Run Gemini pull request review` step in `.github/workflows/gemini-review.yml`.
- Added a `Prepare prompt context` step to create `.gemini/context.json` using `jq` in `.github/workflows/gemini-review.yml`.
- Updated `.gemini/commands/gemini-review.toml` to read context from `@{.gemini/context.json}` instead of using environment variables directly in the prompt.
- Updated `settings` in `.github/workflows/gemini-review.yml` to use `shell` with `allowEnv` and `allowCommands` instead of the deprecated `tools` configuration.
- Added `extensions` referencing `https://github.com/gemini-cli-extensions/code-review` in `.github/workflows/gemini-review.yml`.

## References
- Fixes are based on the changes in MaxText PR: https://github.com/AI-Hypercomputer/maxtext/pull/3780