### PR TITLE
fix: enable ulysses sharding for custom kernels and improve scaling precision

### DIFF
--- a/src/maxdiffusion/models/attention_flax.py
+++ b/src/maxdiffusion/models/attention_flax.py
@@ -35,6 +35,7 @@ from ..kernels import custom_splash_attention as custom_splash
 from . import quantizations
 from .modeling_flax_utils import get_activation
 
+LOG2E = math.log2(math.e)
 
 Array = common_types.Array
 Mesh = common_types.Mesh
@@ -591,9 +592,7 @@ def _ulysses_attention(
           heads_per_tile = getattr(flash_block_sizes, "heads_per_tile", heads_per_tile)
 
       if use_base2_exp:
-        query_scaled = query * 1.44269504
-      else:
-        query_scaled = query
+        query = query * LOG2E
 
       query, kv_size, query_seq_len = _pad_data_for_flash(query, heads, bq)
       key, _, key_seq_len = _pad_data_for_flash(key, heads, bkv)
@@ -612,7 +611,7 @@ def _ulysses_attention(
       )
 
       vmapped_splash = jax.vmap(splash_kernel, in_axes=(0, 0, 0))
-      attention_output = vmapped_splash(query_scaled, key, value)
+      attention_output = vmapped_splash(query, key, value)
       attention_output = jnp.swapaxes(attention_output, 2, 3)
       attention_output = attention_output[:, :, :query_seq_len, :kv_size].astype(query.dtype)
     else:

--- a/src/maxdiffusion/pyconfig.py
+++ b/src/maxdiffusion/pyconfig.py
@@ -214,7 +214,7 @@ class _HyperParameters:
     # Verify qkv is sharded across sequence.
     attention = raw_keys["attention"]
     uses_ring_attention = "ring" in attention
-    uses_ulysses_attention = attention == "ulysses"
+    uses_ulysses_attention = "ulysses" in attention
     uses_uniform_sequence_sharding = raw_keys["attention_sharding_uniform"]
     if uses_ring_attention or uses_ulysses_attention or uses_uniform_sequence_sharding:
       max_logging.log(


### PR DESCRIPTION
# Description

This PR introduces two small but important fixes to the Ulysses attention implementation:
1. **Enable Ulysses sharding for custom kernels**: In `src/maxdiffusion/pyconfig.py`, the check for Ulysses attention is changed from `attention == "ulysses"` to `"ulysses" in attention`. This ensures that custom attention implementations that include "ulysses" in their identifier (e.g., `custom_ulysses`) will correctly trigger Ulysses sequence sharding instead of falling back to default sharding strategies.
3. **Ensure correct padding**: In `src/maxdiffusion/models/attention_flax.py`, padding was done for `query` variable but `query_scaled` was used in the attention calculation. This fixes it and ensures the padded variable is used in the attention calculation. 
2. **Improve scaling precision**: In `src/maxdiffusion/models/attention_flax.py`, the hardcoded constant `1.44269504` used to scale queries for base-2 exponentiation is replaced with `math.log2(math.e)`. This provides better precision and makes the intent of the code clearer.


## Generation Time
- **Main**: ~420s
- **Branch**: ~140s