### PR TITLE
Cancel in-progress workflow runs on new push

### DIFF
--- a/.github/workflows/CPUTests.yml
+++ b/.github/workflows/CPUTests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpu:
     name: "CPU tests"

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -26,6 +26,10 @@ on:
     # Run the job every 12 hours
     - cron:  '0 */12 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary
- Adds `concurrency` groups to `CPUTests.yml` (Linter) and `UnitTests.yml` (Unit Test) workflows
- When a new commit is pushed to the same branch, any in-progress run of that workflow is automatically cancelled
- Scoped per workflow + branch, so runs on different branches don't interfere with each other