### PR TITLE
Fixes import errors for huggingface_hub.utils

### DIFF
--- a/src/maxdiffusion/configuration_utils.py
+++ b/src/maxdiffusion/configuration_utils.py
@@ -29,7 +29,11 @@ import numpy as np
 from dataclasses import asdict, is_dataclass
 
 from huggingface_hub import create_repo, hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+
+try:
+  from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+except ImportError:
+  from huggingface_hub.v0.errors import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from requests import HTTPError
 import jax.numpy as jnp
 from . import __version__

--- a/src/maxdiffusion/loaders/flux_lora_pipeline.py
+++ b/src/maxdiffusion/loaders/flux_lora_pipeline.py
@@ -18,7 +18,11 @@ from ..models.lora import LoRALinearLayer, BaseLoRALayer
 import jax.numpy as jnp
 from flax.traverse_util import flatten_dict
 from ..models.modeling_flax_pytorch_utils import convert_flux_lora_pytorch_state_dict_to_flax
-from huggingface_hub.utils import validate_hf_hub_args
+
+try:
+  from huggingface_hub.utils import validate_hf_hub_args
+except ImportError:
+  from huggingface_hub.v0.utils import validate_hf_hub_args
 
 
 class FluxLoraLoaderMixin(LoRABaseMixin):

--- a/src/maxdiffusion/loaders/lora_pipeline.py
+++ b/src/maxdiffusion/loaders/lora_pipeline.py
@@ -22,7 +22,11 @@ from .lora_conversion_utils import (
     _maybe_map_sgm_blocks_to_diffusers,
 )
 from ..models.modeling_flax_pytorch_utils import convert_lora_pytorch_state_dict_to_flax
-from huggingface_hub.utils import validate_hf_hub_args
+
+try:
+  from huggingface_hub.utils import validate_hf_hub_args
+except ImportError:
+  from huggingface_hub.v0.utils import validate_hf_hub_args
 
 TEXT_ENCODER_NAME = "text_encoder"
 UNET_NAME = "unet"

--- a/src/maxdiffusion/models/ltx2/latent_upsampler_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/latent_upsampler_ltx2.py
@@ -24,7 +24,11 @@ import jax.numpy as jnp
 from flax import nnx
 
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+
+try:
+  from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+except ImportError:
+  from huggingface_hub.v0.utils import EntryNotFoundError, HfHubHTTPError
 
 RATIONAL_RESAMPLER_SCALE_MAPPING = {
     0.75: (3, 4),

--- a/src/maxdiffusion/models/ltx2/ltx2_utils.py
+++ b/src/maxdiffusion/models/ltx2/ltx2_utils.py
@@ -21,7 +21,12 @@ import jax
 import jax.numpy as jnp
 from maxdiffusion import max_logging
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError
+
+try:
+  from huggingface_hub.utils import EntryNotFoundError
+except ImportError:
+  from huggingface_hub.v0.utils import EntryNotFoundError
+
 from safetensors import safe_open
 from flax.traverse_util import unflatten_dict, flatten_dict
 from ..modeling_flax_pytorch_utils import (rename_key, rename_key_and_reshape_tensor, torch2jax, validate_flax_state_dict)

--- a/src/maxdiffusion/models/modeling_flax_utils.py
+++ b/src/maxdiffusion/models/modeling_flax_utils.py
@@ -24,7 +24,11 @@ from flax.core.frozen_dict import FrozenDict
 from flax.serialization import from_bytes, to_bytes
 from flax.traverse_util import flatten_dict, unflatten_dict
 from huggingface_hub import create_repo, hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+
+try:
+  from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+except ImportError:
+  from huggingface_hub.v0.utils import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from requests import HTTPError
 
 from .. import __version__, is_torch_available

--- a/src/maxdiffusion/trainers/dreambooth_trainer.py
+++ b/src/maxdiffusion/trainers/dreambooth_trainer.py
@@ -28,7 +28,11 @@ from flax.linen import partitioning as nn_partitioning
 import optax
 import torch
 from torch.utils.data import Dataset
-from huggingface_hub.utils import insecure_hashlib
+
+try:
+  from huggingface_hub.utils import insecure_hashlib
+except ImportError:
+  from huggingface_hub.v0.utils import insecure_hashlib
 from tqdm import tqdm
 
 from maxdiffusion.trainers.base_stable_diffusion_trainer import BaseStableDiffusionTrainer

--- a/src/maxdiffusion/utils/hub_utils.py
+++ b/src/maxdiffusion/utils/hub_utils.py
@@ -26,12 +26,21 @@ from uuid import uuid4
 
 from huggingface_hub import ModelCard, ModelCardData, create_repo, get_token, hf_hub_download, upload_folder, whoami
 from huggingface_hub.file_download import REGEX_COMMIT_HASH
-from huggingface_hub.utils import (
-    EntryNotFoundError,
-    RepositoryNotFoundError,
-    RevisionNotFoundError,
-    is_jinja_available,
-)
+
+try:
+  from huggingface_hub.utils import (
+      EntryNotFoundError,
+      RepositoryNotFoundError,
+      RevisionNotFoundError,
+      is_jinja_available,
+  )
+except ImportError:
+  from huggingface_hub.v0.utils import (
+      EntryNotFoundError,
+      RepositoryNotFoundError,
+      RevisionNotFoundError,
+      is_jinja_available,
+  )
 from packaging import version
 from requests import HTTPError
 

--- a/src/maxdiffusion/utils/import_utils.py
+++ b/src/maxdiffusion/utils/import_utils.py
@@ -23,7 +23,10 @@ from itertools import chain
 from types import ModuleType
 from typing import Any, Union
 
-from huggingface_hub.utils import is_jinja_available  # noqa: F401
+try:
+  from huggingface_hub.utils import is_jinja_available  # noqa: F401
+except ImportError:
+  from huggingface_hub.v0.utils import is_jinja_available  # noqa: F401
 from packaging import version
 from packaging.version import Version, parse
 


### PR DESCRIPTION
In some platforms the import is slightly different due to multiple versions of the library being present. This adds a try-catch clause to handle those scenarios.