### PR TITLE
Fix NaN in LTX2 scheduler when dynamic shift saturates sigmas before `shift_terminal`

### DIFF
--- a/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
+++ b/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
@@ -1345,9 +1345,11 @@ class LTX2Pipeline:
 
     video_sequence_length = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
     video_sequence_length *= (height // self.vae_spatial_compression_ratio) * (width // self.vae_spatial_compression_ratio)
+    # Cap long videos while preserving smaller videos' dynamic shift behavior.
+    shift_sequence_length = min(6144, video_sequence_length)
 
     mu = calculate_shift(
-        video_sequence_length,
+        shift_sequence_length,
         self.scheduler.config.get("base_image_seq_len", 1024),
         self.scheduler.config.get("max_image_seq_len", 4096),
         self.scheduler.config.get("base_shift", 0.95),


### PR DESCRIPTION
## Fix NaN in LTX2 scheduler when dynamic shift saturates sigmas before `shift_terminal`

This commit fixes a numerical stability issue in the LTX2 scheduler when processing very long video sequences.

In `ltx2_pipeline`, the dynamic shift value is calculated from `video_sequence_length`:

```python
mu = calculate_shift(
    video_sequence_length,
    self.scheduler.config.get("base_image_seq_len", 1024),
    self.scheduler.config.get("max_image_seq_len", 4096),
    self.scheduler.config.get("base_shift", 0.95),
    self.scheduler.config.get("max_shift", 2.05),
)
```

For very long sequences, `mu` can become very large. For example, when `mu` reaches around `48`, the exponential dynamic shifting logic in `set_timesteps_ltx2` becomes numerically saturated:

```python
sigmas = jnp.exp(current_shift) / (
    jnp.exp(current_shift)
    + (1 / jnp.clip(sigmas, 1e-7, 1.0) - 1) ** 1.0
)
```

The issue is **not** that `exp(48)` overflows in `float32`. `exp(48)` is still finite in fp32. The actual problem happens after dynamic shifting.

When `current_shift` is large enough, `jnp.exp(current_shift)` dominates the denominator. As a result, the shifted `sigmas` can become numerically saturated to exactly `1.0`.

The later `shift_terminal` logic assumes that `1 - sigmas[-1]` is non-zero:

```python
one_minus_z = 1 - sigmas
scale_factor = one_minus_z[-1] / (1 - shift_terminal)
sigmas = 1 - (one_minus_z / scale_factor)
```

However, when dynamic shifting has already saturated all `sigmas` to `1.0`, this becomes:

```python
one_minus_z = 1 - 1.0 = 0
scale_factor = one_minus_z[-1] / (1 - shift_terminal)
             = 0 / (1 - shift_terminal)
             = 0
```

Then the final rescaling step evaluates:

```python
one_minus_z / scale_factor
```

which becomes:

```text
0 / 0
```

and produces `NaN`.
