### PR TITLE
feat(ltx2): implement centralized, configuration-driven logical sharding strategy for LTX-2 and LTX-2.3

### DIFF
--- a/src/maxdiffusion/configs/ltx2_3_video.yml
+++ b/src/maxdiffusion/configs/ltx2_3_video.yml
@@ -14,9 +14,13 @@ remat_policy: "NONE"
 jax_cache_dir: ''
 weights_dtype: 'bfloat16'
 activations_dtype: 'bfloat16'
+text_encoder_dtype: 'bfloat16'
+compile_text_encoder: False
+use_batched_text_encoder: False
 
 run_name: 'ltx2_inference'
 output_dir: ''
+base_output_directory: ''
 config_path: ''
 save_config_to_gcs: False
 
@@ -68,6 +72,11 @@ logical_axis_rules: [
                       ['conv_out', 'context'],
                     ]
 data_sharding: ['data', 'fsdp', 'context', 'tensor']
+
+sharding:
+  transformer: 'default'
+  vae: 'default'
+  text_connector: 'default'
 
 dcn_data_parallelism: 1  # recommended DCN axis to be auto-sharded
 dcn_fsdp_parallelism: -1

--- a/src/maxdiffusion/configs/ltx2_video.yml
+++ b/src/maxdiffusion/configs/ltx2_video.yml
@@ -20,9 +20,13 @@ remat_policy: "NONE"
 jax_cache_dir: ''
 weights_dtype: 'bfloat16'
 activations_dtype: 'bfloat16'
+text_encoder_dtype: 'bfloat16'
+compile_text_encoder: False
+use_batched_text_encoder: False
 
 run_name: 'ltx2_inference'
 output_dir: ''
+base_output_directory: ''
 config_path: ''
 save_config_to_gcs: False
 
@@ -73,6 +77,11 @@ logical_axis_rules: [
                       ['conv_out', 'context'],
                     ]
 data_sharding: ['data', 'fsdp', 'context', 'tensor']
+
+sharding:
+  transformer: 'default'
+  vae: 'default'
+  text_connector: 'default'
 
 dcn_data_parallelism: 1  # recommended DCN axis to be auto-sharded
 dcn_fsdp_parallelism: -1

--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -20,7 +20,14 @@ limitations under the License.
 import functools
 from functools import partial, reduce
 from contextlib import nullcontext
-from typing import Dict, Callable
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Set,
+    Tuple,
+    Union,
+)
 import json
 import yaml
 import os
@@ -36,7 +43,6 @@ import jax.numpy as jnp
 import optax
 from maxdiffusion import max_logging
 from maxdiffusion.checkpointing import checkpointing_utils
-from maxdiffusion.models.attention_flax import AttentionOp
 import flax.linen as nn
 import flax.linen.module as module_lib
 from flax.linen.summary import _process_inputs
@@ -50,13 +56,6 @@ from jax.experimental import mesh_utils
 
 from transformers import FlaxCLIPTextModel, FlaxCLIPTextPreTrainedModel
 from flax import struct
-from typing import (
-    Callable,
-    Any,
-    Tuple,
-    Union,
-    Set,
-)
 from flax import core
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
 
@@ -676,6 +675,8 @@ def get_live_arrays():
 # to retrieve layer parameters and calculate
 def calculate_model_tflops(module: module_lib.Module, rngs: Union[PRNGKey, RNGSequences], train, **kwargs):
   """Calculates model tflops by passing a module."""
+  from maxdiffusion.models.attention_flax import AttentionOp
+
   with module_lib._tabulate_context():
     _ = jax.eval_shape(module.init, rngs, **kwargs)
     calls = module_lib._context.call_info_stack[-1].calls
@@ -769,3 +770,8 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     max_logging.log("Jax distributed system initialized on GPU!")
   else:
     jax.distributed.initialize()
+
+
+def safe_getattr(obj: Any, name: str, default: Any) -> Any:
+  """Safely reads attribute from an object, returning default if obj is None or attribute missing."""
+  return getattr(obj, name, default) if obj is not None else default

--- a/src/maxdiffusion/models/attention_flax.py
+++ b/src/maxdiffusion/models/attention_flax.py
@@ -15,7 +15,7 @@
 import contextlib
 import functools
 import math
-from typing import Optional, Callable, Tuple, Dict
+from typing import Optional, Callable, Tuple, Any, Dict
 import flax.linen as nn
 from flax import nnx
 import jax
@@ -31,6 +31,7 @@ from maxdiffusion.kernels.splash_attention import base as tokamax_splash_base
 from einops import rearrange
 from .. import common_types, max_logging
 from maxdiffusion.tpu_utils import get_tpu_type, TpuType
+from maxdiffusion.max_utils import safe_getattr
 
 
 from ..kernels import custom_splash_attention as custom_splash
@@ -1133,24 +1134,15 @@ class NNXSimpleFeedForward(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: Optional[jax.lax.Precision] = None,
+      sharding_specs: Optional[Any] = None,
   ):
     inner_dim = int(dim * mult)
     dim_out = dim_out if dim_out is not None else dim
 
-    tpu_type = get_tpu_type()
-    is_ironwood = tpu_type == TpuType.TPU_7X
-
-    # Hardware-aware sharding specs: Ironwood (v7x) keeps the embedding dimension (embed)
-    # replicated (None) to minimize cross-device communication, while other hardware (default)
-    # shards it to prevent OOM issues.
-    if is_ironwood:
-      net0_kernel_spec = (None, "mlp")
-      net2_kernel_spec = ("mlp", None)
-      net2_bias_spec = (None,)
-    else:
-      net0_kernel_spec = ("embed", "mlp")
-      net2_kernel_spec = ("mlp", "embed")
-      net2_bias_spec = ("embed",)
+    net_0_kernel = safe_getattr(sharding_specs, "net_0_kernel", ("embed", "mlp"))
+    net_0_bias = safe_getattr(sharding_specs, "net_0_bias", ("mlp",))
+    net_2_kernel = safe_getattr(sharding_specs, "net_2_kernel", ("mlp", "embed"))
+    net_2_bias = safe_getattr(sharding_specs, "net_2_bias", ("embed",))
 
     self.net_0 = nnx.Linear(
         dim,
@@ -1160,8 +1152,8 @@ class NNXSimpleFeedForward(nnx.Module):
         dtype=dtype,
         param_dtype=weights_dtype,
         precision=precision,
-        kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), net0_kernel_spec),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("mlp",)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), net_0_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, net_0_bias),
     )
     self.act = get_activation(activation_fn)
     self.net_2 = nnx.Linear(
@@ -1172,8 +1164,8 @@ class NNXSimpleFeedForward(nnx.Module):
         dtype=dtype,
         param_dtype=weights_dtype,
         precision=precision,
-        kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), net2_kernel_spec),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, net2_bias_spec),
+        kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), net_2_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, net_2_bias),
     )
 
   def __call__(self, hidden_states: Array) -> Array:

--- a/src/maxdiffusion/models/embeddings_flax.py
+++ b/src/maxdiffusion/models/embeddings_flax.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from typing import Optional
+from typing import Optional, Any
 import flax.linen as nn
 from flax import nnx
 import jax.numpy as jnp
@@ -22,6 +22,7 @@ from .modeling_flax_utils import get_activation
 from ..models.attention_flax import NNXSimpleFeedForward
 from ..models.normalization_flax import FP32LayerNorm
 from maxdiffusion.tpu_utils import get_tpu_type, TpuType
+from maxdiffusion.max_utils import safe_getattr
 
 
 def get_sinusoidal_embeddings(
@@ -85,7 +86,12 @@ class NNXTimestepEmbedding(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
+    linear_1_kernel = safe_getattr(sharding_specs, "emb_linear_1_kernel", ("embed", "mlp"))
+    linear_1_bias = safe_getattr(sharding_specs, "emb_linear_1_bias", ("mlp",))
+    linear_2_kernel = safe_getattr(sharding_specs, "emb_linear_2_kernel", ("mlp", "embed"))
+    linear_2_bias = safe_getattr(sharding_specs, "emb_linear_2_bias", ("embed",))
     self.linear_1 = nnx.Linear(
         rngs=rngs,
         in_features=in_channels,
@@ -96,12 +102,9 @@ class NNXTimestepEmbedding(nnx.Module):
         precision=precision,
         kernel_init=nnx.with_partitioning(
             nnx.initializers.xavier_uniform(),
-            (
-                "embed",
-                "mlp",
-            ),
+            linear_1_kernel,
         ),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("mlp",)),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, linear_1_bias),
     )
 
     if cond_proj_dim is not None:
@@ -128,12 +131,9 @@ class NNXTimestepEmbedding(nnx.Module):
         precision=precision,
         kernel_init=nnx.with_partitioning(
             nnx.initializers.xavier_uniform(),
-            (
-                "mlp",
-                "embed",
-            ),
+            linear_2_kernel,
         ),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("embed",)),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, linear_2_bias),
     )
 
     if post_act_fn is None:
@@ -341,7 +341,12 @@ class NNXPixArtAlphaTextProjection(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
+    linear_1_kernel = safe_getattr(sharding_specs, "emb_linear_1_kernel", ("embed", "mlp"))
+    linear_1_bias = safe_getattr(sharding_specs, "emb_linear_1_bias", ("mlp",))
+    linear_2_kernel = safe_getattr(sharding_specs, "emb_linear_2_kernel", ("mlp", "embed"))
+    linear_2_bias = safe_getattr(sharding_specs, "emb_linear_2_bias", ("embed",))
     if out_features is None:
       out_features = hidden_size
 
@@ -355,12 +360,9 @@ class NNXPixArtAlphaTextProjection(nnx.Module):
         precision=precision,
         kernel_init=nnx.with_partitioning(
             nnx.initializers.xavier_uniform(),
-            (
-                "embed",
-                "mlp",
-            ),
+            linear_1_kernel,
         ),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("mlp",)),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, linear_1_bias),
     )
     self.act_1 = get_activation(act_fn)
 
@@ -374,12 +376,9 @@ class NNXPixArtAlphaTextProjection(nnx.Module):
         precision=precision,
         kernel_init=nnx.with_partitioning(
             nnx.initializers.xavier_uniform(),
-            (
-                "mlp",
-                "embed",
-            ),
+            linear_2_kernel,
         ),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("embed",)),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, linear_2_bias),
     )
 
   def __call__(self, caption):
@@ -535,22 +534,38 @@ class NNXPixArtAlphaCombinedTimestepSizeEmbeddings(nnx.Module):
       use_additional_conditions: bool = False,
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
+      sharding_specs: Optional[Any] = None,
   ):
     self.outdim = size_emb_dim
     self.use_additional_conditions = use_additional_conditions
 
     self.time_proj = NNXTimesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
     self.timestep_embedder = NNXTimestepEmbedding(
-        rngs=rngs, in_channels=256, time_embed_dim=embedding_dim, dtype=dtype, weights_dtype=weights_dtype
+        rngs=rngs,
+        in_channels=256,
+        time_embed_dim=embedding_dim,
+        dtype=dtype,
+        weights_dtype=weights_dtype,
+        sharding_specs=sharding_specs,
     )
 
     if use_additional_conditions:
       self.additional_condition_proj = NNXTimesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
       self.resolution_embedder = NNXTimestepEmbedding(
-          rngs=rngs, in_channels=256, time_embed_dim=size_emb_dim, dtype=dtype, weights_dtype=weights_dtype
+          rngs=rngs,
+          in_channels=256,
+          time_embed_dim=size_emb_dim,
+          dtype=dtype,
+          weights_dtype=weights_dtype,
+          sharding_specs=sharding_specs,
       )
       self.aspect_ratio_embedder = NNXTimestepEmbedding(
-          rngs=rngs, in_channels=256, time_embed_dim=size_emb_dim, dtype=dtype, weights_dtype=weights_dtype
+          rngs=rngs,
+          in_channels=256,
+          time_embed_dim=size_emb_dim,
+          dtype=dtype,
+          weights_dtype=weights_dtype,
+          sharding_specs=sharding_specs,
       )
 
   def __call__(

--- a/src/maxdiffusion/models/ltx2/attention_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/attention_ltx2.py
@@ -20,7 +20,7 @@ import jax
 import jax.numpy as jnp
 from ... import common_types
 from ..attention_flax import NNXAttentionOp
-from maxdiffusion.tpu_utils import get_tpu_type, TpuType
+from .logical_sharding_ltx2 import get_sharding_specs, LTX2DiTShardingSpecs
 
 Array = common_types.Array
 Mesh = common_types.Mesh
@@ -350,9 +350,7 @@ class LTX2Attention(nnx.Module):
       rope_type: str = "interleaved",
       flash_block_sizes: BlockSizes = None,
       flash_min_seq_length: int = 4096,
-      qkv_sharding_spec: Optional[tuple] = None,
-      out_sharding_spec: Optional[tuple] = None,
-      out_bias_sharding_spec: Optional[tuple] = None,
+      sharding_specs: Optional[LTX2DiTShardingSpecs] = None,
       gated_attn: bool = False,
   ):
     self.heads = heads
@@ -361,33 +359,24 @@ class LTX2Attention(nnx.Module):
     self.inner_dim = dim_head * heads
     self.dropout_rate = dropout
 
-    # Auto-detect hardware for sharding specs if not overridden
-    tpu_type = get_tpu_type()
-    is_ironwood = tpu_type == TpuType.TPU_7X
-
-    # Hardware-aware sharding: Ironwood (v7x) uses 1D sharding along the heads dimension (leaving the embedding dimension replicated)
-    # to minimize cross-device communication, while other hardware defaults to 2D sharding along both heads and embed dimensions.
-    # This has currently only been tested on Trillium (v6e) and Ironwood (v7x).
-    if qkv_sharding_spec is None:
-      qkv_sharding_spec = (None, "heads") if is_ironwood else ("embed", "heads")
-    if out_sharding_spec is None:
-      out_sharding_spec = ("heads", None) if is_ironwood else ("heads", "embed")
-    if out_bias_sharding_spec is None:
-      out_bias_sharding_spec = (None,) if is_ironwood else ("embed",)
+    if sharding_specs is None:
+      specs = get_sharding_specs("default", "ltx2_dit")
+    else:
+      specs = sharding_specs
 
     # 1. Define Partitioned Initializers (Logical Axes)
     # Q, K, V kernels: [in_features (embed), out_features (heads)]
-    qkv_kernel_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), qkv_sharding_spec)
+    qkv_kernel_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), specs.qkv_kernel)
     # Q, K, V biases: [out_features (heads)]
-    qkv_bias_init = nnx.with_partitioning(nnx.initializers.zeros_init(), ("heads",))
+    qkv_bias_init = nnx.with_partitioning(nnx.initializers.zeros_init(), specs.qkv_bias)
 
     # Out kernel: [in_features (heads), out_features (embed)]
-    out_kernel_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), out_sharding_spec)
+    out_kernel_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), specs.out_kernel)
     # Out bias: [out_features (embed)]
-    out_bias_init = nnx.with_partitioning(nnx.initializers.zeros_init(), out_bias_sharding_spec)
+    out_bias_init = nnx.with_partitioning(nnx.initializers.zeros_init(), specs.out_bias)
 
     # Norm scales
-    norm_scale_init = nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",))
+    norm_scale_init = nnx.with_partitioning(nnx.initializers.ones_init(), specs.norm_scale)
 
     # 2. Projections
     self.to_q = nnx.Linear(
@@ -450,8 +439,8 @@ class LTX2Attention(nnx.Module):
           query_dim,
           heads,
           use_bias=True,
-          kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), ("embed", "heads")),
-          bias_init=nnx.with_partitioning(nnx.initializers.zeros_init(), ("heads",)),
+          kernel_init=nnx.with_partitioning(nnx.initializers.lecun_normal(), specs.gate_logits_kernel),
+          bias_init=nnx.with_partitioning(nnx.initializers.zeros_init(), specs.gate_logits_bias),
           rngs=rngs,
           dtype=dtype,
       )

--- a/src/maxdiffusion/models/ltx2/autoencoder_kl_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/autoencoder_kl_ltx2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Union, Optional, Sequence
+from typing import Tuple, Union, Optional, Sequence, Any
 from enum import Enum
 
 
@@ -180,6 +180,7 @@ class LTX2VideoResnetBlock3d(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     out_channels = out_channels or in_channels
     self.nonlinearity = get_activation(non_linearity)
@@ -233,15 +234,18 @@ class LTX2VideoResnetBlock3d(nnx.Module):
       self.conv_shortcut = None
 
     if inject_noise:
-      self.per_channel_scale1 = nnx.Param(jnp.zeros((in_channels,), dtype=dtype))
-      self.per_channel_scale2 = nnx.Param(jnp.zeros((in_channels,), dtype=dtype))
+      sharding = sharding_specs.per_channel_scale if sharding_specs is not None else None
+      self.per_channel_scale1 = nnx.Param(jnp.zeros((in_channels,), dtype=dtype), sharding=sharding)
+      self.per_channel_scale2 = nnx.Param(jnp.zeros((in_channels,), dtype=dtype), sharding=sharding)
     else:
       self.per_channel_scale1 = None
       self.per_channel_scale2 = None
 
     if timestep_conditioning:
+      sharding = sharding_specs.scale_shift_table if sharding_specs is not None else None
       self.scale_shift_table = nnx.Param(
-          jax.random.normal(rngs.params(), (4, in_channels), dtype=dtype) / (in_channels**0.5)
+          jax.random.normal(rngs.params(), (4, in_channels), dtype=dtype) / (in_channels**0.5),
+          sharding=sharding,
       )
     else:
       self.scale_shift_table = None
@@ -469,9 +473,11 @@ class LTX2VideoDownBlock3D(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     out_channels = out_channels or in_channels
     self.num_layers = num_layers
+    self.sharding_specs = sharding_specs
 
     @nnx.split_rngs(splits=num_layers)
     @nnx.vmap(in_axes=0, out_axes=0, axis_size=num_layers)
@@ -488,6 +494,7 @@ class LTX2VideoDownBlock3D(nnx.Module):
           dtype=dtype,
           weights_dtype=weights_dtype,
           precision=precision,
+          sharding_specs=sharding_specs,
       )
 
     self.resnets = create_resnets(rngs)
@@ -599,6 +606,7 @@ class LTX2VideoMidBlock3d(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     if timestep_conditioning:
       self.time_embedder = nnx.data(
@@ -609,6 +617,7 @@ class LTX2VideoMidBlock3d(nnx.Module):
               use_additional_conditions=False,
               dtype=dtype,
               weights_dtype=weights_dtype,
+              sharding_specs=sharding_specs,
           )
       )
     else:
@@ -633,6 +642,7 @@ class LTX2VideoMidBlock3d(nnx.Module):
           dtype=dtype,
           weights_dtype=weights_dtype,
           precision=precision,
+          sharding_specs=sharding_specs,
       )
 
     self.resnets = create_resnets(rngs)
@@ -690,6 +700,7 @@ class LTX2VideoUpBlock3d(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     out_channels = out_channels or in_channels
 
@@ -703,6 +714,7 @@ class LTX2VideoUpBlock3d(nnx.Module):
               use_additional_conditions=False,
               dtype=dtype,
               weights_dtype=weights_dtype,
+              sharding_specs=sharding_specs,
           )
       )
 
@@ -723,6 +735,7 @@ class LTX2VideoUpBlock3d(nnx.Module):
               dtype=dtype,
               weights_dtype=weights_dtype,
               precision=precision,
+              sharding_specs=sharding_specs,
           )
       )
 
@@ -769,6 +782,7 @@ class LTX2VideoUpBlock3d(nnx.Module):
           dtype=dtype,
           weights_dtype=weights_dtype,
           precision=precision,
+          sharding_specs=sharding_specs,
       )
 
     self.resnets = create_resnets(rngs)
@@ -844,11 +858,13 @@ class LTX2VideoEncoder3d(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     self.patch_size = patch_size
     self.patch_size_t = patch_size_t
     self.in_channels = in_channels * patch_size**2
     self.is_causal = is_causal
+    self.sharding_specs = sharding_specs
 
     output_channel = out_channels
 
@@ -882,6 +898,7 @@ class LTX2VideoEncoder3d(nnx.Module):
                 dtype=dtype,
                 weights_dtype=weights_dtype,
                 precision=precision,
+                sharding_specs=sharding_specs,
             )
             for i in range(num_block_out_channels)
         ]
@@ -901,6 +918,7 @@ class LTX2VideoEncoder3d(nnx.Module):
         dtype=dtype,
         weights_dtype=weights_dtype,
         precision=precision,
+        sharding_specs=sharding_specs,
     )
 
     # out
@@ -994,6 +1012,7 @@ class LTX2VideoDecoder3d(nnx.Module):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     self.patch_size = patch_size
     self.patch_size_t = patch_size_t
@@ -1033,6 +1052,7 @@ class LTX2VideoDecoder3d(nnx.Module):
         dtype=dtype,
         weights_dtype=weights_dtype,
         precision=precision,
+        sharding_specs=sharding_specs,
     )
 
     # up blocks
@@ -1061,6 +1081,7 @@ class LTX2VideoDecoder3d(nnx.Module):
               dtype=dtype,
               weights_dtype=weights_dtype,
               precision=precision,
+              sharding_specs=sharding_specs,
           )
       )
 
@@ -1094,6 +1115,7 @@ class LTX2VideoDecoder3d(nnx.Module):
               use_additional_conditions=False,
               dtype=dtype,
               weights_dtype=weights_dtype,
+              sharding_specs=sharding_specs,
           )
       )
     else:
@@ -1200,6 +1222,7 @@ class LTX2VideoAutoencoderKL(nnx.Module, FlaxModelMixin, ConfigMixin):
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
       precision: jax.lax.Precision = None,
+      sharding_specs: Optional[Any] = None,
   ):
     self.encoder = LTX2VideoEncoder3d(
         in_channels=in_channels,
@@ -1219,6 +1242,7 @@ class LTX2VideoAutoencoderKL(nnx.Module, FlaxModelMixin, ConfigMixin):
         dtype=dtype,
         weights_dtype=weights_dtype,
         precision=precision,
+        sharding_specs=sharding_specs,
     )
 
     self.decoder = LTX2VideoDecoder3d(
@@ -1242,6 +1266,7 @@ class LTX2VideoAutoencoderKL(nnx.Module, FlaxModelMixin, ConfigMixin):
         dtype=dtype,
         weights_dtype=weights_dtype,
         precision=precision,
+        sharding_specs=sharding_specs,
     )
 
     self.scaling_factor = scaling_factor

--- a/src/maxdiffusion/models/ltx2/logical_sharding_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/logical_sharding_ltx2.py
@@ -1,0 +1,174 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from maxdiffusion.tpu_utils import get_tpu_type, TpuType
+from maxdiffusion import max_logging
+
+
+# --- Discrete Specs ---
+@dataclass
+class LTX2DiTShardingSpecs:
+  """Sharding specs for the LTX2 Diffusion Transformer."""
+
+  # --- Attention Layers (LTX2Attention) ---
+  qkv_kernel: tuple = ("embed", "heads")
+  out_kernel: tuple = ("heads", "embed")
+  out_bias: tuple = ("embed",)
+  qkv_bias: tuple = ("heads",)
+  gate_logits_kernel: tuple = ("embed", "heads")
+  gate_logits_bias: tuple = ("heads",)
+
+  # --- Feed Forward Network (NNXSimpleFeedForward) ---
+  net_0_kernel: tuple = ("embed", "mlp")
+  net_0_bias: tuple = ("mlp",)
+  net_2_kernel: tuple = ("mlp", "embed")
+  net_2_bias: tuple = ("embed",)
+
+  # --- Input/Output Projections and Tables ---
+  embed_kernel: tuple = (None, "embed")
+  embed_bias: tuple = ("embed",)
+  adaln_kernel: tuple = (None, "embed")
+  adaln_bias: tuple = ("embed",)
+  scale_shift_table: tuple = (None, "embed")
+  out_embed_kernel: tuple = ("embed", None)
+  out_embed_bias: tuple = (None,)
+
+  # --- Shared Embeddings (NNXTimestepEmbedding, NNXPixArtAlphaTextProjection) ---
+  emb_linear_1_kernel: tuple = ("embed", "mlp")
+  emb_linear_1_bias: tuple = ("mlp",)
+  emb_linear_2_kernel: tuple = ("mlp", "embed")
+  emb_linear_2_bias: tuple = ("embed",)
+
+  # --- Normalization ---
+  norm_scale: tuple = ("norm",)
+
+
+@dataclass
+class TextConnectorShardingSpecs:
+  """Specs for the Text Connector execution."""
+
+  # --- MLP Specs (NNXSimpleFeedForward) ---
+  net_0_kernel: tuple = ("embed", "mlp")
+  net_0_bias: tuple = ("mlp",)
+  net_2_kernel: tuple = ("mlp", "embed")
+  net_2_bias: tuple = ("embed",)
+
+  # --- Attention Specs (LTX2Attention) ---
+  qkv_kernel: tuple = ("embed", "heads")
+  out_kernel: tuple = ("heads", "embed")
+  out_bias: tuple = ("embed",)
+  qkv_bias: tuple = ("heads",)
+  gate_logits_kernel: tuple = ("embed", "heads")
+  gate_logits_bias: tuple = ("heads",)
+  norm_scale: tuple = ("norm",)
+
+  # --- Projection Specs (feature_extractor / per_modality_projections) ---
+  proj_kernel: tuple = (None, None)
+  proj_bias: tuple = (None,)
+
+
+@dataclass
+class VAEShardingSpecs:
+  """Sharding specs for the VAE."""
+
+  # --- Shared Embeddings Specs (NNXPixArtAlphaCombinedTimestepSizeEmbeddings) ---
+  emb_linear_1_kernel: tuple = ("embed", "mlp")
+  emb_linear_1_bias: tuple = ("mlp",)
+  emb_linear_2_kernel: tuple = ("mlp", "embed")
+  emb_linear_2_bias: tuple = ("embed",)
+
+  # --- ResNet Block Specs ---
+  scale_shift_table: tuple = (None, None)
+  per_channel_scale: tuple = (None,)
+
+
+# --- Unified Registry for LTX2 ---
+STRATEGIES = {
+    "ironwood": {
+        "ltx2_dit": LTX2DiTShardingSpecs(
+            qkv_kernel=(None, "heads"),
+            qkv_bias=("heads",),
+            out_kernel=("heads", None),
+            out_bias=(None,),
+            gate_logits_kernel=(None, "heads"),
+            gate_logits_bias=("heads",),
+            net_0_kernel=(None, "mlp"),
+            net_2_kernel=("mlp", None),
+            net_2_bias=(None,),
+            embed_kernel=(None, None),
+            embed_bias=(None,),
+            adaln_kernel=(None, None),
+            adaln_bias=(None,),
+            scale_shift_table=(None, None),
+            out_embed_kernel=(None, None),
+            out_embed_bias=(None,),
+            emb_linear_1_kernel=(None, "mlp"),
+            emb_linear_2_kernel=("mlp", None),
+            emb_linear_2_bias=(None,),
+            norm_scale=(None,),
+        ),
+        "text_connector": TextConnectorShardingSpecs(
+            qkv_kernel=(None, "heads"),
+            qkv_bias=("heads",),
+            out_kernel=("heads", None),
+            out_bias=(None,),
+            gate_logits_kernel=(None, "heads"),
+            gate_logits_bias=("heads",),
+            net_0_kernel=(None, "mlp"),
+            net_2_kernel=("mlp", None),
+            net_2_bias=(None,),
+            norm_scale=(None,),
+        ),
+        "vae": VAEShardingSpecs(
+            emb_linear_1_kernel=(None, "mlp"),
+            emb_linear_2_kernel=("mlp", None),
+            emb_linear_2_bias=(None,),
+        ),
+    },
+    "trillium": {
+        "ltx2_dit": LTX2DiTShardingSpecs(),
+        "text_connector": TextConnectorShardingSpecs(),
+        "vae": VAEShardingSpecs(),
+    },
+}
+
+
+def get_sharding_specs(strategy_name: str, component_name: str) -> Any:
+  """Unified factory to get specs for any component.
+
+  If strategy_name is 'default', it auto-detects the hardware.
+  """
+  if strategy_name == "default":
+    tpu_type = get_tpu_type()
+    if tpu_type == TpuType.TPU_7X:
+      strategy_name = "ironwood"
+    else:
+      strategy_name = "trillium"
+
+  if strategy_name not in STRATEGIES:
+    max_logging.log(
+        f"Warning: Strategy '{strategy_name}' is not recognized in the LTX2 registry. "
+        f"Falling back to the highly compatible 'trillium' strategy profile."
+    )
+    strategy_name = "trillium"
+
+  hardware_profile = STRATEGIES[strategy_name]
+  specs = hardware_profile.get(component_name)
+  if specs is None:
+    raise ValueError(f"Component {component_name} not found in strategy {strategy_name}")
+  return specs

--- a/src/maxdiffusion/models/ltx2/text_encoders/embeddings_connector_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/text_encoders/embeddings_connector_ltx2.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 import jax
 import jax.numpy as jnp
 from flax import nnx
@@ -37,6 +37,7 @@ class _BasicTransformerBlock1D(nnx.Module):
       attention_kernel: str = "flash",
       mesh: jax.sharding.Mesh = None,
       rngs: nnx.Rngs = None,
+      sharding_specs: Optional[Any] = None,
       gated_attn: bool = False,
   ):
     self.attn1 = LTX2Attention(
@@ -49,9 +50,10 @@ class _BasicTransformerBlock1D(nnx.Module):
         attention_kernel=attention_kernel,
         mesh=mesh,
         rngs=rngs,
+        sharding_specs=sharding_specs,
         gated_attn=gated_attn,
     )
-    self.ff = NNXSimpleFeedForward(rngs=rngs, dim=dim, dim_out=dim, activation_fn="gelu_tanh")
+    self.ff = NNXSimpleFeedForward(rngs=rngs, dim=dim, dim_out=dim, activation_fn="gelu_tanh", sharding_specs=sharding_specs)
     self.norm1 = nnx.RMSNorm(dim, epsilon=1e-6, dtype=jnp.float32, param_dtype=jnp.float32, use_scale=False, rngs=rngs)
     self.norm2 = nnx.RMSNorm(dim, epsilon=1e-6, dtype=jnp.float32, param_dtype=jnp.float32, use_scale=False, rngs=rngs)
 
@@ -94,6 +96,7 @@ class Embeddings1DConnector(nnx.Module):
       attention_kernel: str = "flash",
       mesh: jax.sharding.Mesh = None,
       rngs: nnx.Rngs = None,
+      sharding_specs: Optional[Any] = None,
       gated_attn: bool = False,
   ):
     self.dim = input_dim
@@ -120,6 +123,7 @@ class Embeddings1DConnector(nnx.Module):
           attention_kernel=attention_kernel,
           mesh=mesh,
           rngs=rngs,
+          sharding_specs=sharding_specs,
           gated_attn=gated_attn,
       )
 

--- a/src/maxdiffusion/models/ltx2/text_encoders/feature_extractor_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/text_encoders/feature_extractor_ltx2.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 import jax.numpy as jnp
 from flax import nnx
 from maxdiffusion import common_types
@@ -106,6 +106,7 @@ class LTX2GemmaFeatureExtractor(nnx.Module):
       use_bias: bool = False,
       video_output_dim: Optional[int] = None,
       audio_output_dim: Optional[int] = None,
+      sharding_specs: Optional[Any] = None,
   ):
     """
     Args:
@@ -114,13 +115,44 @@ class LTX2GemmaFeatureExtractor(nnx.Module):
     """
     self.per_modality_projections = per_modality_projections
 
+    if sharding_specs is not None:
+      proj_k_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), sharding_specs.proj_kernel)
+      proj_b_init = nnx.with_partitioning(nnx.initializers.zeros, sharding_specs.proj_bias)
+    else:
+      proj_k_init = nnx.initializers.lecun_normal()
+      proj_b_init = nnx.initializers.zeros
+
     if per_modality_projections:
       v_dim = video_output_dim if video_output_dim is not None else output_dim
       a_dim = audio_output_dim if audio_output_dim is not None else output_dim
-      self.video_linear = nnx.Linear(input_dim, v_dim, use_bias=use_bias, dtype=dtype, rngs=rngs)
-      self.audio_linear = nnx.Linear(input_dim, a_dim, use_bias=use_bias, dtype=dtype, rngs=rngs)
+      self.video_linear = nnx.Linear(
+          input_dim,
+          v_dim,
+          use_bias=use_bias,
+          dtype=dtype,
+          rngs=rngs,
+          kernel_init=proj_k_init,
+          bias_init=proj_b_init,
+      )
+      self.audio_linear = nnx.Linear(
+          input_dim,
+          a_dim,
+          use_bias=use_bias,
+          dtype=dtype,
+          rngs=rngs,
+          kernel_init=proj_k_init,
+          bias_init=proj_b_init,
+      )
     else:
-      self.linear = nnx.Linear(input_dim, output_dim, use_bias=use_bias, dtype=dtype, rngs=rngs)
+      self.linear = nnx.Linear(
+          input_dim,
+          output_dim,
+          use_bias=use_bias,
+          dtype=dtype,
+          rngs=rngs,
+          kernel_init=proj_k_init,
+          bias_init=proj_b_init,
+      )
 
   def __call__(self, hidden_states: Union[Tuple[Array, ...], Array], attention_mask: Array) -> Array:
     """

--- a/src/maxdiffusion/models/ltx2/text_encoders/text_encoders_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/text_encoders/text_encoders_ltx2.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, Tuple, Union, List
+from typing import Optional, Tuple, Union, List, Any
 import jax
 import jax.numpy as jnp
 from flax import nnx
@@ -59,6 +59,7 @@ class LTX2AudioVideoGemmaTextEncoder(nnx.Module, FlaxModelMixin, ConfigMixin):
       attention_kernel: str = "flash",
       mesh: jax.sharding.Mesh = None,
       rngs: nnx.Rngs = None,
+      sharding_specs: Optional[Any] = None,
       per_modality_projections: bool = False,
       proj_bias: bool = False,
       video_gated_attn: bool = False,
@@ -85,8 +86,28 @@ class LTX2AudioVideoGemmaTextEncoder(nnx.Module, FlaxModelMixin, ConfigMixin):
     self.per_modality_projections = per_modality_projections
 
     if per_modality_projections:
-      self.video_text_proj_in = nnx.Linear(in_features=input_dim, out_features=v_dim, use_bias=proj_bias, rngs=rngs)
-      self.audio_text_proj_in = nnx.Linear(in_features=input_dim, out_features=a_dim, use_bias=proj_bias, rngs=rngs)
+      if sharding_specs is not None:
+        proj_k_init = nnx.with_partitioning(nnx.initializers.lecun_normal(), sharding_specs.proj_kernel)
+        proj_b_init = nnx.with_partitioning(nnx.initializers.zeros, sharding_specs.proj_bias)
+      else:
+        proj_k_init = nnx.initializers.lecun_normal()
+        proj_b_init = nnx.initializers.zeros
+      self.video_text_proj_in = nnx.Linear(
+          in_features=input_dim,
+          out_features=v_dim,
+          use_bias=proj_bias,
+          rngs=rngs,
+          kernel_init=proj_k_init,
+          bias_init=proj_b_init,
+      )
+      self.audio_text_proj_in = nnx.Linear(
+          in_features=input_dim,
+          out_features=a_dim,
+          use_bias=proj_bias,
+          rngs=rngs,
+          kernel_init=proj_k_init,
+          bias_init=proj_b_init,
+      )
     else:
       self.feature_extractor = LTX2GemmaFeatureExtractor(
           input_dim=input_dim,
@@ -97,6 +118,7 @@ class LTX2AudioVideoGemmaTextEncoder(nnx.Module, FlaxModelMixin, ConfigMixin):
           use_bias=proj_bias,
           video_output_dim=v_dim,
           audio_output_dim=a_dim,
+          sharding_specs=sharding_specs,
       )
 
     # Two independent connectors (used in both LTX-2.0 and LTX-2.3 paths)
@@ -113,6 +135,7 @@ class LTX2AudioVideoGemmaTextEncoder(nnx.Module, FlaxModelMixin, ConfigMixin):
         attention_kernel=attention_kernel,
         mesh=mesh,
         rngs=rngs,
+        sharding_specs=sharding_specs,
         gated_attn=video_gated_attn,
     )
     self.audio_embeddings_connector = Embeddings1DConnector(
@@ -128,6 +151,7 @@ class LTX2AudioVideoGemmaTextEncoder(nnx.Module, FlaxModelMixin, ConfigMixin):
         attention_kernel=attention_kernel,
         mesh=mesh,
         rngs=rngs,
+        sharding_specs=sharding_specs,
         gated_attn=audio_gated_attn,
     )
 

--- a/src/maxdiffusion/models/ltx2/transformer_ltx2.py
+++ b/src/maxdiffusion/models/ltx2/transformer_ltx2.py
@@ -26,6 +26,7 @@ from maxdiffusion.models.embeddings_flax import NNXPixArtAlphaCombinedTimestepSi
 from maxdiffusion.models.gradient_checkpoint import GradientCheckpointType
 from maxdiffusion.configuration_utils import ConfigMixin, register_to_config
 from maxdiffusion.common_types import BlockSizes
+from .logical_sharding_ltx2 import get_sharding_specs, LTX2DiTShardingSpecs
 
 
 class LTX2AdaLayerNormSingle(nnx.Module):
@@ -45,8 +46,12 @@ class LTX2AdaLayerNormSingle(nnx.Module):
       use_additional_conditions: bool = False,
       dtype: jnp.dtype = jnp.float32,
       weights_dtype: jnp.dtype = jnp.float32,
+      sharding_specs: Optional[LTX2DiTShardingSpecs] = None,
   ):
     self.num_mod_params = num_mod_params
+
+    if sharding_specs is None:
+      sharding_specs = get_sharding_specs("default", "ltx2_dit")
     self.use_additional_conditions = use_additional_conditions
     self.emb = NNXPixArtAlphaCombinedTimestepSizeEmbeddings(
         rngs=rngs,
@@ -55,6 +60,7 @@ class LTX2AdaLayerNormSingle(nnx.Module):
         use_additional_conditions=use_additional_conditions,
         dtype=dtype,
         weights_dtype=weights_dtype,
+        sharding_specs=sharding_specs,
     )
     self.silu = nnx.silu
     self.linear = nnx.Linear(
@@ -64,8 +70,8 @@ class LTX2AdaLayerNormSingle(nnx.Module):
         use_bias=True,
         dtype=dtype,
         param_dtype=weights_dtype,
-        kernel_init=nnx.with_partitioning(nnx.initializers.zeros, (None, "embed")),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("embed",)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.zeros, sharding_specs.adaln_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, sharding_specs.adaln_bias),
     )
 
   def __call__(
@@ -120,6 +126,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
       v2a_attention_kernel: str = "dot_product",
       flash_block_sizes: BlockSizes = None,
       flash_min_seq_length: int = 4096,
+      sharding_specs: Optional[LTX2DiTShardingSpecs] = None,
       perturbed_attn: bool = False,
   ):
     self.dim = dim
@@ -127,6 +134,10 @@ class LTX2VideoTransformerBlock(nnx.Module):
     self.norm_elementwise_affine = norm_elementwise_affine
     self.attention_kernel = attention_kernel
     self.perturbed_attn = perturbed_attn
+
+    if sharding_specs is None:
+      sharding_specs = get_sharding_specs("default", "ltx2_dit")
+    self.sharding_specs = sharding_specs
 
     # 1. Self-Attention (video and audio)
     self.norm1 = nnx.RMSNorm(
@@ -136,7 +147,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.attn1 = LTX2Attention(
         rngs=rngs,
@@ -153,6 +164,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
         flash_min_seq_length=flash_min_seq_length,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -163,7 +175,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.audio_attn1 = LTX2Attention(
         rngs=rngs,
@@ -180,6 +192,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
         flash_min_seq_length=flash_min_seq_length,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -191,7 +204,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.attn2 = LTX2Attention(
         rngs=rngs,
@@ -208,6 +221,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         attention_kernel=self.attention_kernel,
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -218,7 +232,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.audio_attn2 = LTX2Attention(
         rngs=rngs,
@@ -236,6 +250,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
         flash_min_seq_length=flash_min_seq_length,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -247,7 +262,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.audio_to_video_attn = LTX2Attention(
         rngs=rngs,
@@ -265,6 +280,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
         flash_min_seq_length=0,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -275,7 +291,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.video_to_audio_attn = LTX2Attention(
         rngs=rngs,
@@ -293,6 +309,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rope_type=rope_type,
         flash_block_sizes=flash_block_sizes,
         flash_min_seq_length=flash_min_seq_length,
+        sharding_specs=self.sharding_specs,
         gated_attn=gated_attn,
     )
 
@@ -304,7 +321,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.ff = NNXSimpleFeedForward(
         rngs=rngs,
@@ -313,6 +330,7 @@ class LTX2VideoTransformerBlock(nnx.Module):
         activation_fn=activation_fn,
         dtype=dtype,
         weights_dtype=weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
 
     self.audio_norm3 = nnx.RMSNorm(
@@ -322,10 +340,16 @@ class LTX2VideoTransformerBlock(nnx.Module):
         rngs=rngs,
         dtype=jnp.float32,
         param_dtype=jnp.float32,
-        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), ("norm",)),
+        scale_init=nnx.with_partitioning(nnx.initializers.ones_init(), self.sharding_specs.norm_scale),
     )
     self.audio_ff = NNXSimpleFeedForward(
-        rngs=rngs, dim=audio_dim, dim_out=audio_dim, activation_fn=activation_fn, dtype=dtype, weights_dtype=weights_dtype
+        rngs=rngs,
+        dim=audio_dim,
+        dim_out=audio_dim,
+        activation_fn=activation_fn,
+        dtype=dtype,
+        weights_dtype=weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
 
     key = rngs.params()
@@ -333,24 +357,44 @@ class LTX2VideoTransformerBlock(nnx.Module):
 
     self.cross_attn_mod = cross_attn_mod
     table_size = 9 if cross_attn_mod else 6
+    table_sharding = self.sharding_specs.scale_shift_table
 
     self.scale_shift_table = nnx.Param(
-        jax.random.normal(k1, (table_size, self.dim), dtype=weights_dtype) / jnp.sqrt(self.dim)
+        nnx.with_partitioning(
+            lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype) / jnp.sqrt(self.dim), table_sharding
+        )(k1, (table_size, self.dim))
     )
 
     if self.cross_attn_mod:
       self.prompt_scale_shift_table = nnx.Param(
-          jax.random.normal(k5, (2, self.dim), dtype=weights_dtype) / jnp.sqrt(self.dim)
+          nnx.with_partitioning(
+              lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype) / jnp.sqrt(self.dim), table_sharding
+          )(k5, (2, self.dim))
       )
 
     self.audio_scale_shift_table = nnx.Param(
-        jax.random.normal(k2, (table_size, audio_dim), dtype=weights_dtype) / jnp.sqrt(audio_dim)
+        nnx.with_partitioning(
+            lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype) / jnp.sqrt(audio_dim), table_sharding
+        )(k2, (table_size, audio_dim))
     )
-    self.video_a2v_cross_attn_scale_shift_table = nnx.Param(jax.random.normal(k3, (5, self.dim), dtype=weights_dtype))
-    self.audio_a2v_cross_attn_scale_shift_table = nnx.Param(jax.random.normal(k4, (5, audio_dim), dtype=weights_dtype))
+
+    self.video_a2v_cross_attn_scale_shift_table = nnx.Param(
+        nnx.with_partitioning(lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype), table_sharding)(
+            k3, (5, self.dim)
+        )
+    )
+
+    self.audio_a2v_cross_attn_scale_shift_table = nnx.Param(
+        nnx.with_partitioning(lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype), table_sharding)(
+            k4, (5, audio_dim)
+        )
+    )
+
     if self.cross_attn_mod:
       self.audio_prompt_scale_shift_table = nnx.Param(
-          jax.random.normal(k6, (2, audio_dim), dtype=weights_dtype) / jnp.sqrt(audio_dim)
+          nnx.with_partitioning(
+              lambda key, shape: jax.random.normal(key, shape, dtype=weights_dtype) / jnp.sqrt(audio_dim), table_sharding
+          )(k6, (2, audio_dim))
       )
 
   def __call__(
@@ -645,6 +689,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
       qk_norm: str = "rms_norm_across_heads",
       flash_block_sizes: BlockSizes = None,
       flash_min_seq_length: int = 4096,
+      sharding_specs: Optional[LTX2DiTShardingSpecs] = None,
       gated_attn: bool = False,
       cross_attn_mod: bool = False,
       use_prompt_embeddings: bool = True,
@@ -706,6 +751,10 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
     self.v2a_attention_kernel = v2a_attention_kernel
     self.flash_min_seq_length = flash_min_seq_length
 
+    if sharding_specs is None:
+      sharding_specs = get_sharding_specs("default", "ltx2_dit")
+    self.sharding_specs = sharding_specs
+
     _out_channels = self.out_channels or self.in_channels
     _audio_out_channels = self.audio_out_channels or self.audio_in_channels
     inner_dim = self.num_attention_heads * self.attention_head_dim
@@ -718,8 +767,8 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         rngs=rngs,
         dtype=self.dtype,
         param_dtype=self.weights_dtype,
-        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), (None, "embed")),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("embed",)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), self.sharding_specs.embed_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, self.sharding_specs.embed_bias),
     )
     self.audio_proj_in = nnx.Linear(
         self.audio_in_channels,
@@ -727,8 +776,8 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         rngs=rngs,
         dtype=self.dtype,
         param_dtype=self.weights_dtype,
-        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), (None, "embed")),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, ("embed",)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), self.sharding_specs.embed_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, self.sharding_specs.embed_bias),
     )
 
     if self.use_prompt_embeddings:
@@ -738,6 +787,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
           hidden_size=inner_dim,
           dtype=self.dtype,
           weights_dtype=self.weights_dtype,
+          sharding_specs=self.sharding_specs,
       )
       self.audio_caption_projection = NNXPixArtAlphaTextProjection(
           rngs=rngs,
@@ -745,6 +795,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
           hidden_size=audio_inner_dim,
           dtype=self.dtype,
           weights_dtype=self.weights_dtype,
+          sharding_specs=self.sharding_specs,
       )
     else:
       self.caption_projection = None
@@ -758,6 +809,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
           use_additional_conditions=False,
           dtype=self.dtype,
           weights_dtype=self.weights_dtype,
+          sharding_specs=self.sharding_specs,
       )
       self.audio_prompt_adaln = LTX2AdaLayerNormSingle(
           rngs=rngs,
@@ -766,6 +818,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
           use_additional_conditions=False,
           dtype=self.dtype,
           weights_dtype=self.weights_dtype,
+          sharding_specs=self.sharding_specs,
       )
     # 3. Timestep Modulation Params and Embedding
     num_mod_params = 9 if self.cross_attn_mod else 6
@@ -776,6 +829,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
     self.audio_time_embed = LTX2AdaLayerNormSingle(
         rngs=rngs,
@@ -784,6 +838,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
     self.av_cross_attn_video_scale_shift = LTX2AdaLayerNormSingle(
         rngs=rngs,
@@ -792,6 +847,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
     self.av_cross_attn_audio_scale_shift = LTX2AdaLayerNormSingle(
         rngs=rngs,
@@ -800,6 +856,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
     self.av_cross_attn_video_a2v_gate = LTX2AdaLayerNormSingle(
         rngs=rngs,
@@ -808,6 +865,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
     self.av_cross_attn_audio_v2a_gate = LTX2AdaLayerNormSingle(
         rngs=rngs,
@@ -816,15 +874,22 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         use_additional_conditions=False,
         dtype=self.dtype,
         weights_dtype=self.weights_dtype,
+        sharding_specs=self.sharding_specs,
     )
 
     # 3. Output Layer Scale/Shift Modulation parameters
     param_rng = rngs.params()
+    table_sharding = self.sharding_specs.scale_shift_table
     self.scale_shift_table = nnx.Param(
-        jax.random.normal(param_rng, (2, inner_dim), dtype=self.weights_dtype) / jnp.sqrt(inner_dim)
+        nnx.with_partitioning(
+            lambda key, shape: jax.random.normal(key, shape, dtype=self.weights_dtype) / jnp.sqrt(inner_dim), table_sharding
+        )(param_rng, (2, inner_dim))
     )
     self.audio_scale_shift_table = nnx.Param(
-        jax.random.normal(param_rng, (2, audio_inner_dim), dtype=self.weights_dtype) / jnp.sqrt(audio_inner_dim)
+        nnx.with_partitioning(
+            lambda key, shape: jax.random.normal(key, shape, dtype=self.weights_dtype) / jnp.sqrt(audio_inner_dim),
+            table_sharding,
+        )(param_rng, (2, audio_inner_dim))
     )
 
     # 4. Rotary Positional Embeddings (RoPE)
@@ -895,6 +960,7 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
     def init_block(rngs):
       return LTX2VideoTransformerBlock(
           rngs=rngs,
+          sharding_specs=self.sharding_specs,
           dim=inner_dim,
           num_attention_heads=self.num_attention_heads,
           attention_head_dim=self.attention_head_dim,
@@ -977,8 +1043,8 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         rngs=rngs,
         dtype=self.dtype,
         param_dtype=self.weights_dtype,
-        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), ("embed", None)),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, (None,)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), self.sharding_specs.out_embed_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, self.sharding_specs.out_embed_bias),
     )
 
     self.audio_norm_out = nnx.LayerNorm(
@@ -990,8 +1056,8 @@ class LTX2VideoTransformer3DModel(nnx.Module, ConfigMixin):
         rngs=rngs,
         dtype=self.dtype,
         param_dtype=self.weights_dtype,
-        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), ("embed", None)),
-        bias_init=nnx.with_partitioning(nnx.initializers.zeros, (None,)),
+        kernel_init=nnx.with_partitioning(nnx.initializers.xavier_uniform(), self.sharding_specs.out_embed_kernel),
+        bias_init=nnx.with_partitioning(nnx.initializers.zeros, self.sharding_specs.out_embed_bias),
     )
 
   def __call__(

--- a/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
+++ b/src/maxdiffusion/pipelines/ltx2/ltx2_pipeline.py
@@ -25,7 +25,6 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from torchax import default_env
 from maxdiffusion.models.ltx2.text_encoders.torchax_text_encoder import TorchaxGemma3TextEncoder
-from maxdiffusion.tpu_utils import get_tpu_type, TpuType
 from maxdiffusion.maxdiffusion_utils import get_dummy_ltx2_inputs
 import contextlib
 import flax
@@ -42,6 +41,7 @@ from ...models.ltx2.autoencoder_kl_ltx2_audio import FlaxAutoencoderKLLTX2Audio
 from ...models.ltx2.vocoder_ltx2 import LTX2Vocoder, LTX2VocoderWithBWE
 from ...models.ltx2.transformer_ltx2 import LTX2VideoTransformer3DModel
 from ...models.ltx2.latent_upsampler_ltx2 import LTX2LatentUpsamplerModel
+from ...models.ltx2.logical_sharding_ltx2 import get_sharding_specs
 from ...models.ltx2.ltx2_utils import (
     load_transformer_weights,
     load_connector_weights,
@@ -59,6 +59,13 @@ from ...pyconfig import HyperParameters
 from ... import max_logging
 from ... import max_utils
 from ...max_utils import get_precision, device_put_replicated, get_flash_block_sizes
+
+
+TORCH_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
 
 
 @flax.struct.dataclass
@@ -147,6 +154,11 @@ def create_sharded_logical_transformer(
   ltx2_config["names_which_can_be_saved"] = config.names_which_can_be_saved
   ltx2_config["names_which_can_be_offloaded"] = config.names_which_can_be_offloaded
   ltx2_config["spatio_temporal_guidance_blocks"] = tuple(getattr(config, "spatio_temporal_guidance_blocks", ()))
+
+  sharding_config = getattr(config, "sharding", {})
+  transformer_strategy = sharding_config.get("transformer", "default")
+  dit_specs = get_sharding_specs(transformer_strategy, "ltx2_dit")
+  ltx2_config["sharding_specs"] = dit_specs
 
   # 2. eval_shape
   p_model_factory = partial(create_model, ltx2_config=ltx2_config)
@@ -251,6 +263,7 @@ class LTX2Pipeline:
       vocoder: Union[LTX2Vocoder, LTX2VocoderWithBWE],
       latent_upsampler: Optional[LTX2LatentUpsamplerModel] = None,
       latent_upsampler_params: Optional[dict] = None,
+      config: Optional[HyperParameters] = None,
   ):
     self.scheduler = scheduler
     self.vae = vae
@@ -263,7 +276,7 @@ class LTX2Pipeline:
     self.latent_upsampler = latent_upsampler
     self.latent_upsampler_params = latent_upsampler_params
     self.mesh = None
-    self.config = None
+    self.config = config
 
     # VAE compression ratios
     self.vae_spatial_compression_ratio = getattr(self.vae, "spatial_compression_ratio", 32)
@@ -325,10 +338,17 @@ class LTX2Pipeline:
   @classmethod
   def load_text_encoder(cls, config: HyperParameters):
     max_logging.log("Loading Gemma3 Text Encoder...")
+    dtype_obj = getattr(config, "text_encoder_dtype", "float32")
+    dtype_str = dtype_obj.name if hasattr(dtype_obj, "name") else str(dtype_obj)
+
+    if dtype_str not in TORCH_DTYPE_MAP:
+      raise ValueError(f"Unsupported text_encoder_dtype: {dtype_str}. Supported values are: {list(TORCH_DTYPE_MAP.keys())}")
+    torch_dtype = TORCH_DTYPE_MAP[dtype_str]
+
     text_encoder = Gemma3ForConditionalGeneration.from_pretrained(
         config.pretrained_model_name_or_path,
         subfolder="text_encoder",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=torch_dtype,
     )
     text_encoder.eval()
 
@@ -336,6 +356,9 @@ class LTX2Pipeline:
       with default_env():
         text_encoder = text_encoder.to("jax")
         text_encoder = TorchaxGemma3TextEncoder(text_encoder)
+    elif getattr(config, "compile_text_encoder", False):
+      max_logging.log("Compiling Gemma3 Text Encoder...")
+      text_encoder = torch.compile(text_encoder)
 
     return text_encoder
 
@@ -344,6 +367,10 @@ class LTX2Pipeline:
     max_logging.log("Loading Connectors...")
 
     def create_model(rngs: nnx.Rngs, config: HyperParameters):
+      sharding_config = getattr(config, "sharding", {})
+      connector_strategy = sharding_config.get("text_connector", "default")
+      connector_specs = get_sharding_specs(connector_strategy, "text_connector")
+
       connectors = LTX2AudioVideoGemmaTextEncoder.from_config(
           config.pretrained_model_name_or_path,
           subfolder="connectors",
@@ -351,6 +378,7 @@ class LTX2Pipeline:
           mesh=mesh,
           dtype=jnp.float32,
           weights_dtype=config.weights_dtype if hasattr(config, "weights_dtype") else jnp.float32,
+          sharding_specs=connector_specs,
       )
       return connectors
 
@@ -386,6 +414,10 @@ class LTX2Pipeline:
     max_logging.log("Loading Video VAE...")
 
     def create_model(rngs: nnx.Rngs, config: HyperParameters):
+      sharding_config = getattr(config, "sharding", {})
+      vae_strategy = sharding_config.get("vae", "default")
+      vae_specs = get_sharding_specs(vae_strategy, "vae")
+
       vae = LTX2VideoAutoencoderKL.from_config(
           config.pretrained_model_name_or_path,
           subfolder="vae",
@@ -393,6 +425,7 @@ class LTX2Pipeline:
           mesh=mesh,
           dtype=jnp.float32,
           weights_dtype=config.weights_dtype if hasattr(config, "weights_dtype") else jnp.float32,
+          sharding_specs=vae_specs,
       )
       return vae
 
@@ -713,9 +746,9 @@ class LTX2Pipeline:
         vocoder=components["vocoder"],
         latent_upsampler=latent_upsampler,
         latent_upsampler_params=latent_upsampler_params,
+        config=config,
     )
     pipeline.mesh = components["mesh"]
-    pipeline.config = config
     if load_transformer:
       pipeline.transformer = cls.quantize_transformer(config, pipeline.transformer, pipeline, pipeline.mesh)
     return pipeline, pipeline.transformer
@@ -945,9 +978,7 @@ class LTX2Pipeline:
     else:
       batch_size = prompt_embeds[0].shape[0] if isinstance(prompt_embeds, list) else prompt_embeds.shape[0]
 
-    tpu_type = get_tpu_type()
-    # Batching text encoder gives better results on Ironwood (v7x) but poor on Trillium (v6e)
-    use_batched_text_encoder = tpu_type == TpuType.TPU_7X
+    use_batched_text_encoder = self.config.use_batched_text_encoder
 
     if use_batched_text_encoder and prompt_embeds is None and do_classifier_free_guidance and negative_prompt_embeds is None:
       negative_prompt = negative_prompt or ""

--- a/src/maxdiffusion/pipelines/wan/wan_pipeline.py
+++ b/src/maxdiffusion/pipelines/wan/wan_pipeline.py
@@ -54,6 +54,13 @@ except ModuleNotFoundError:
 import PIL
 
 
+TORCH_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+
+
 def cast_with_exclusion(path, x, dtype_to_cast):
   """
   Casts arrays to dtype_to_cast, but keeps params from any 'norm' layer in float32.
@@ -297,7 +304,12 @@ class WanPipeline:
   @classmethod
   def load_text_encoder(cls, config: HyperParameters):
     text_encoder_dtype = getattr(config, "text_encoder_dtype", "float32")
-    torch_dtype = getattr(torch, str(text_encoder_dtype), torch.float32)
+    dtype_str = text_encoder_dtype.name if hasattr(text_encoder_dtype, "name") else str(text_encoder_dtype)
+
+    if dtype_str not in TORCH_DTYPE_MAP:
+      raise ValueError(f"Unsupported text_encoder_dtype: {dtype_str}. Supported values are: {list(TORCH_DTYPE_MAP.keys())}")
+    torch_dtype = TORCH_DTYPE_MAP[dtype_str]
+
     text_encoder = UMT5EncoderModel.from_pretrained(
         config.pretrained_model_name_or_path,
         subfolder="text_encoder",
@@ -566,7 +578,7 @@ class WanPipeline:
     elif isinstance(negative_prompt, str):
       negative_prompt = [negative_prompt] * batch_size
 
-    use_batched_text_encoder = getattr(self.config, "use_batched_text_encoder", False)
+    use_batched_text_encoder = self.config.use_batched_text_encoder
     if use_batched_text_encoder and prompt_embeds is None and negative_prompt_embeds is None:
       # Batch both together
       combined_prompts = prompt + negative_prompt

--- a/src/maxdiffusion/pyconfig.py
+++ b/src/maxdiffusion/pyconfig.py
@@ -196,6 +196,15 @@ class _HyperParameters:
   @staticmethod
   def user_init(raw_keys):
     """Transformations between the config data and configs used at runtime"""
+    # Set default for use_batched_text_encoder if not present
+    if "use_batched_text_encoder" not in raw_keys:
+      raw_keys["use_batched_text_encoder"] = False
+
+    # Validate that use_batched_text_encoder is a boolean
+    if not isinstance(raw_keys["use_batched_text_encoder"], bool):
+      raise TypeError(
+          f"Expected config.use_batched_text_encoder to be a boolean, but got {type(raw_keys['use_batched_text_encoder'])}"
+      )
     # Set defaults for dtypes if they weren't explicitly provided
     if "vae_dtype" not in raw_keys:
       raw_keys["vae_dtype"] = "float32"
@@ -205,7 +214,14 @@ class _HyperParameters:
       raw_keys["scheduler_dtype"] = "float32"
 
     # Cast all dtype configs to jax.numpy.dtype
-    for dtype_key in ["weights_dtype", "activations_dtype", "scheduler_dtype", "vae_dtype", "vae_weights_dtype"]:
+    for dtype_key in [
+        "weights_dtype",
+        "activations_dtype",
+        "scheduler_dtype",
+        "vae_dtype",
+        "vae_weights_dtype",
+        "text_encoder_dtype",
+    ]:
       if dtype_key in raw_keys:
         raw_keys[dtype_key] = jax.numpy.dtype(raw_keys[dtype_key])
     if raw_keys["run_name"] == "":

--- a/src/maxdiffusion/tests/ltx2/test_logical_sharding_ltx2.py
+++ b/src/maxdiffusion/tests/ltx2/test_logical_sharding_ltx2.py
@@ -1,0 +1,117 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from unittest.mock import patch
+from maxdiffusion.models.ltx2.logical_sharding_ltx2 import (
+    get_sharding_specs,
+    LTX2DiTShardingSpecs,
+    TextConnectorShardingSpecs,
+    VAEShardingSpecs,
+)
+
+
+class TestLogicalShardingLTX2(unittest.TestCase):
+
+  def test_get_sharding_specs_ironwood(self):
+    specs = get_sharding_specs("ironwood", "ltx2_dit")
+    self.assertIsInstance(specs, LTX2DiTShardingSpecs)
+    # Check specific ironwood overrides
+    self.assertEqual(specs.qkv_kernel, (None, "heads"))
+    self.assertEqual(specs.out_kernel, ("heads", None))
+    self.assertEqual(specs.embed_kernel, (None, None))
+    self.assertEqual(specs.norm_scale, (None,))
+    # Check specific defaults that should be retained
+    self.assertEqual(specs.qkv_bias, ("heads",))
+    self.assertEqual(specs.net_0_bias, ("mlp",))
+
+  def test_get_sharding_specs_trillium(self):
+    specs = get_sharding_specs("trillium", "ltx2_dit")
+    self.assertIsInstance(specs, LTX2DiTShardingSpecs)
+    # Check specific trillium defaults (FSDP)
+    self.assertEqual(specs.qkv_kernel, ("embed", "heads"))
+    self.assertEqual(specs.out_kernel, ("heads", "embed"))
+    self.assertEqual(specs.embed_kernel, (None, "embed"))
+    self.assertEqual(specs.norm_scale, ("norm",))
+
+  @patch("maxdiffusion.models.ltx2.logical_sharding_ltx2.get_tpu_type")
+  def test_get_sharding_specs_default_cpu(self, mock_get_tpu_type):
+    from maxdiffusion.tpu_utils import TpuType
+
+    mock_get_tpu_type.return_value = TpuType.UNKNOWN
+    specs = get_sharding_specs("default", "ltx2_dit")
+    self.assertIsInstance(specs, LTX2DiTShardingSpecs)
+    # Unknown should fallback to trillium
+    self.assertEqual(specs.qkv_kernel, ("embed", "heads"))
+
+  @patch("maxdiffusion.models.ltx2.logical_sharding_ltx2.get_tpu_type")
+  def test_get_sharding_specs_default_ironwood(self, mock_get_tpu_type):
+    from maxdiffusion.tpu_utils import TpuType
+
+    mock_get_tpu_type.return_value = TpuType.TPU_7X
+    specs = get_sharding_specs("default", "ltx2_dit")
+    self.assertIsInstance(specs, LTX2DiTShardingSpecs)
+    self.assertEqual(specs.qkv_kernel, (None, "heads"))
+
+  def test_get_sharding_specs_invalid_strategy(self):
+    # Should fallback to trillium with a warning
+    specs = get_sharding_specs("some_made_up_strategy", "ltx2_dit")
+    self.assertIsInstance(specs, LTX2DiTShardingSpecs)
+    self.assertEqual(specs.qkv_kernel, ("embed", "heads"))
+
+  def test_get_sharding_specs_invalid_component(self):
+    with self.assertRaises(ValueError):
+      get_sharding_specs("trillium", "invalid_component")
+
+  def test_text_connector_specs_ironwood(self):
+    specs = get_sharding_specs("ironwood", "text_connector")
+    self.assertIsInstance(specs, TextConnectorShardingSpecs)
+    # Projection specs should be fully replicated on Ironwood
+    self.assertEqual(specs.proj_kernel, (None, None))
+    self.assertEqual(specs.proj_bias, (None,))
+    # Attention specs should match DiT pattern
+    self.assertEqual(specs.qkv_kernel, (None, "heads"))
+
+  def test_text_connector_specs_trillium(self):
+    specs = get_sharding_specs("trillium", "text_connector")
+    self.assertIsInstance(specs, TextConnectorShardingSpecs)
+    # Projection specs should be replicated (matching original behavior)
+    self.assertEqual(specs.proj_kernel, (None, None))
+    self.assertEqual(specs.proj_bias, (None,))
+    # Attention specs should use FSDP defaults
+    self.assertEqual(specs.qkv_kernel, ("embed", "heads"))
+
+  def test_vae_specs_ironwood(self):
+    specs = get_sharding_specs("ironwood", "vae")
+    self.assertIsInstance(specs, VAEShardingSpecs)
+    # ResNet specs should be fully replicated on Ironwood
+    self.assertEqual(specs.scale_shift_table, (None, None))
+    self.assertEqual(specs.per_channel_scale, (None,))
+    # Embedding specs
+    self.assertEqual(specs.emb_linear_1_kernel, (None, "mlp"))
+
+  def test_vae_specs_trillium(self):
+    specs = get_sharding_specs("trillium", "vae")
+    self.assertIsInstance(specs, VAEShardingSpecs)
+    # ResNet specs should be replicated (matching original behavior)
+    self.assertEqual(specs.scale_shift_table, (None, None))
+    self.assertEqual(specs.per_channel_scale, (None,))
+    # Embedding specs should use FSDP defaults
+    self.assertEqual(specs.emb_linear_1_kernel, ("embed", "mlp"))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/src/maxdiffusion/tests/ltx2/test_pipeline_ltx2.py
+++ b/src/maxdiffusion/tests/ltx2/test_pipeline_ltx2.py
@@ -28,6 +28,7 @@ class LTX2PipelineTest(unittest.TestCase):
   def setUp(self):
     self.config = MagicMock()
     self.config.pretrained_model_name_or_path = "test_model"
+    self.config.use_batched_text_encoder = False
 
   def test_calculate_shift(self):
     """Test shift calculation math."""
@@ -82,6 +83,7 @@ class LTX2PipelineTest(unittest.TestCase):
         connectors=MagicMock(),
         transformer=mock_transformer,
         vocoder=MagicMock(),
+        config=self.config,
     )
 
     self.assertEqual(pipeline.vae_spatial_compression_ratio, 8)
@@ -105,6 +107,7 @@ class LTX2PipelineTest(unittest.TestCase):
         connectors=MagicMock(),
         transformer=MagicMock(),
         vocoder=MagicMock(),
+        config=self.config,
     )
 
     # Valid check shouldn't raise
@@ -118,14 +121,9 @@ class LTX2PipelineTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       pipeline.check_inputs(prompt="test", height=64, width=63)
 
-  @patch("maxdiffusion.pipelines.ltx2.ltx2_pipeline.get_tpu_type")
   @patch("maxdiffusion.pipelines.ltx2.ltx2_pipeline.LTX2Pipeline._get_gemma_prompt_embeds")
-  def test_encode_prompt(self, list_embed_mock, mock_get_tpu_type):
-    """Test conditional encoding of positive and negative prompts."""
-    from maxdiffusion.tpu_utils import TpuType
-
-    mock_get_tpu_type.return_value = TpuType.TPU_7X
-
+  def test_encode_prompt(self, list_embed_mock):
+    """Test conditional encoding of positive and negative prompts without batching."""
     pipeline = LTX2Pipeline(
         scheduler=MagicMock(),
         vae=MagicMock(),
@@ -135,26 +133,28 @@ class LTX2PipelineTest(unittest.TestCase):
         connectors=MagicMock(),
         transformer=MagicMock(),
         vocoder=MagicMock(),
+        config=self.config,
     )
+    pipeline.config.sharding = {"text_encoder": "trillium"}
 
-    combined_embeds = jnp.zeros((2, 10, 10))
-    combined_attention_mask = jnp.ones((2, 10))
+    single_embeds = jnp.zeros((1, 10, 10))
+    single_attention_mask = jnp.ones((1, 10))
 
-    # Mock return value for combined prompt encoding
-    list_embed_mock.return_value = (combined_embeds, combined_attention_mask)
+    # Mock return value for single prompt encoding
+    list_embed_mock.return_value = (single_embeds, single_attention_mask)
 
     p_e, p_a, n_e, n_a = pipeline.encode_prompt(
         prompt=["A cute cat"], negative_prompt=["ugly"], do_classifier_free_guidance=True
     )
 
-    # Check mock calls
-    self.assertEqual(list_embed_mock.call_count, 1)
+    # We expect 2 separate calls (one for positive, one for negative)
+    self.assertEqual(list_embed_mock.call_count, 2)
 
     # Check returns
-    np.testing.assert_array_equal(p_e, combined_embeds[:1])
-    np.testing.assert_array_equal(p_a, combined_attention_mask[:1])
-    np.testing.assert_array_equal(n_e, combined_embeds[1:])
-    np.testing.assert_array_equal(n_a, combined_attention_mask[1:])
+    np.testing.assert_array_equal(p_e, single_embeds)
+    np.testing.assert_array_equal(p_a, single_attention_mask)
+    np.testing.assert_array_equal(n_e, single_embeds)
+    np.testing.assert_array_equal(n_a, single_attention_mask)
 
   @patch("maxdiffusion.pipelines.ltx2.ltx2_pipeline.LTX2Pipeline._get_gemma_prompt_embeds")
   def test_encode_prompt_no_cfg(self, list_embed_mock):
@@ -168,6 +168,7 @@ class LTX2PipelineTest(unittest.TestCase):
         connectors=MagicMock(),
         transformer=MagicMock(),
         vocoder=MagicMock(),
+        config=self.config,
     )
 
     prompt_embeds = jnp.zeros((1, 10, 10))


### PR DESCRIPTION
### Summary
This PR introduces a centralized, configuration-driven logical sharding strategy registry for **LTX-2** and **LTX-2.3** in MaxDiffusion. It eliminates ad-hoc hardware checks and hardcoded sharding constraints in model layers by moving sharding specifications to a centralized, hardware-aware registry.
### Key Changes
* **Centralized Specs Registry**: Created `logical_sharding_ltx2.py` to define sharding spec profiles for **Ironwood** (TPU v7x, 1D heads-wise sharding) and **Trillium** (TPU v6e, 2D heads + embed sharding).
* **Model Weight Parameterization**: Replaced hardcoded partitioning in LTX2 transformer, attention, VAE timestep embeddings, connectors, and the new LTX-2.3 gated attention projection layers.
* **Decoupled Shared Layers**: Parameterized shared FFN and text projection layers in `attention_flax.py` and `embeddings_flax.py` using generic duck-typing interfaces (`getattr` fallback logic) to prevent code coupling.
* **Config-Driven Pipeline Choices**: Moved VAE replication (`force_replication`) and text-encoding batching (`use_batched_text_encoder`) pipeline decisions to be configuration-driven under the central spec registry.
* **Robust Configuration & CLI support**: Added `sharding`, `text_encoder_dtype`, `compile_text_encoder`, and `base_output_directory` parameters to LTX-2/2.3 configs, enabling dynamic text-encoder compilation and clean overrides via the CLI.
* **Verification**: Added non-brittle unit tests (`test_logical_sharding_ltx2.py`) to verify routing and hardware auto-detection logic.


### Performance

| Model | Baseline (Denoising) | This PR (Denoising) | Change |
| :--- | :--- | :--- | :--- |
| **LTX2** | 10.5s | 10.5s | No change |
| **LTX2.3** | 19.6s | 19.6s | No change |

Conclusion: This change is purely structuring and does not impact peformance
