### PR TITLE
Add `heads_per_tile` (multi-head-per-tile) support to Ulysses ring attention

### DIFF
--- a/src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py
+++ b/src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py
@@ -21,6 +21,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from jax import random
+from jax.experimental import multihost_utils
 import jax.numpy as jnp
 import numpy as np
 from . import base
@@ -158,6 +159,138 @@ class RingAttentionTest(test_utils.SplashAttentionTestCase):
       self._assert_allclose(dq, dq_ref, rtol=1e-2, atol=1e-2)
       self._assert_allclose(dk, dk_ref, rtol=1e-2, atol=1e-2)
       self._assert_allclose(dv, dv_ref, rtol=1e-2, atol=1e-2)
+
+
+class RingAttentionHeadsPerTileTest(test_utils.SplashAttentionTestCase):
+  """`heads_per_tile` (multi-head-per-tile) invariance for ring attention.
+
+  heads_per_tile is a pure tiling/scheduling choice for the forward kernel: for a
+  fixed input, running with heads_per_tile=N must produce the same output as
+  heads_per_tile=1. This guards against the block-index class of bug (a wrong
+  head-tile mapping compiles and runs but silently returns garbage).
+  """
+
+  def setUp(self):
+    if jax.default_backend() != "tpu":
+      self.skipTest("Multi-head-per-tile ring attention runs on TPU.")
+    super().setUp()
+
+  @parameterized.product(
+      heads_per_tile=[2, 4],
+      head_dim=[128],
+      dtype=[jnp.bfloat16],
+  )
+  def test_heads_per_tile_matches_single_head(self, heads_per_tile, head_dim, dtype):
+    # Use ALL devices so the sharded outputs are addressable on every process
+    # (a subset mesh like jax.devices()[:2] lives only on process 0, making the
+    # result non-addressable on the other hosts). jax.devices() is itself a
+    # global barrier, so every host must launch this test together regardless.
+    ring_size = jax.device_count()
+    num_heads = 8  # MHA (num_q_heads == num_kv_heads); divisible by heads_per_tile.
+    if ring_size < 2:
+      self.skipTest(f"This test needs at least 2 devices, but has {ring_size}.")
+
+    ring_axis = "ring"
+    devices = np.asarray(jax.devices()).reshape(1, ring_size)
+    mesh = jax.sharding.Mesh(devices, ("heads", ring_axis))
+    seq_len = 1024 * ring_size
+
+    k1, k2, k3 = random.split(random.key(0), 3)
+    scale = head_dim**-0.5
+    q = random.normal(k1, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+    k = random.normal(k2, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+    v = random.normal(k3, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+
+    # The mhpt fast path supports full MHA + static FullMask + HEAD_DIM_MINOR only.
+    mask = mask_lib.FullMask(_shape=(seq_len, seq_len))
+    q_spec = P(None, ring_axis, None)
+    kv_spec = q_spec
+
+    def run_multi_head_kernel(hpt):
+      config = splash.SplashConfig.get_default()
+      config = dataclasses.replace(
+          config,
+          use_base2_exp=False,
+          fuse_reciprocal=True,
+          heads_per_tile=hpt,
+      )
+      ring_kernel = ring_attention_kernel.make_ring_attention(
+          mask,
+          is_mqa=False,
+          ring_axis=ring_axis,
+          config=config,
+          save_residuals=False,
+          q_seq_shards=ring_size,
+          kv_seq_shards=ring_size,
+      )
+      kernel_spec = ring_kernel.manual_sharding_spec()
+
+      @partial(
+          jax.shard_map,
+          mesh=mesh,
+          in_specs=(kernel_spec, q_spec, kv_spec, kv_spec, None),
+          out_specs=q_spec,
+          check_vma=False,
+      )
+      def ring_attn(ring_kernel, q, k, v, segment_ids):
+        return ring_kernel(q, k, v, segment_ids)
+
+      return ring_attn(ring_kernel, q, k, v, None)
+
+    out_ref = run_multi_head_kernel(1)  # baseline: single head per tile (flash_attention_kernel)
+    out_mhpt = run_multi_head_kernel(heads_per_tile)  # multi-head-per-tile (flash_attention_kernel_mhpt)
+
+    # Pure tiling => numerically equivalent to the single-head-per-tile baseline.
+    # Outputs are sharded across all hosts; all-gather to a fully-replicated host
+    # array on every process, then compare with the standard helper.
+    out_mhpt = multihost_utils.process_allgather(out_mhpt, tiled=True)
+    out_ref = multihost_utils.process_allgather(out_ref, tiled=True)
+    self._assert_allclose(out_mhpt, out_ref, rtol=5e-3, atol=5e-3)
+
+
+class RingAttentionHeadsPerTileGuardTest(test_utils.SplashAttentionTestCase):
+  """Negative scenarios: configurations the heads_per_tile > 1 fast path rejects.
+
+  The mhpt kernel only supports full-MHA static-FullMask ring attention;
+  `_validate_heads_per_tile_support` must reject everything else with
+  NotImplementedError instead of letting the kernel silently miscompute.
+  Pure-Python validation, so no TPU is required.
+  """
+
+  _EMPTY_MASK_INFO = splash.MaskInfo(None, None, None, None, None, None, None)
+
+  def _validate(self, **overrides):
+    kwargs = dict(
+        config=splash.SplashConfig.get_default(),
+        dynamic_grid=False,
+        is_mqa=False,
+        q_heads_per_kv_head=1,
+        mask_info=self._EMPTY_MASK_INFO,
+        mask_function=None,
+        sinks=None,
+        max_logit_value=None,
+    )
+    kwargs.update(overrides)
+    splash._validate_heads_per_tile_support(**kwargs)  # pylint: disable=protected-access
+
+  def test_supported_config_is_accepted(self):
+    self._validate()  # full MHA + static FullMask: must not raise
+
+  def test_mqa_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "MHA"):
+      self._validate(is_mqa=True)
+
+  def test_gqa_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "MHA"):
+      self._validate(q_heads_per_kv_head=2)
+
+  def test_dynamic_grid_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "static ring attention grids"):
+      self._validate(dynamic_grid=True)
+
+  def test_non_full_mask_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "FullMask"):
+      self._validate(mask_function=lambda *args: True)
 
 
 if __name__ == "__main__":

--- a/src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py
+++ b/src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py
@@ -21,6 +21,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from jax import random
+from jax.experimental import multihost_utils
 import jax.numpy as jnp
 import numpy as np
 from . import base
@@ -158,6 +159,138 @@ class RingAttentionTest(test_utils.SplashAttentionTestCase):
       self._assert_allclose(dq, dq_ref, rtol=1e-2, atol=1e-2)
       self._assert_allclose(dk, dk_ref, rtol=1e-2, atol=1e-2)
       self._assert_allclose(dv, dv_ref, rtol=1e-2, atol=1e-2)
+
+
+class RingAttentionHeadsPerTileTest(test_utils.SplashAttentionTestCase):
+  """`heads_per_tile` (multi-head-per-tile) invariance for ring attention.
+
+  heads_per_tile is a pure tiling/scheduling choice for the forward kernel: for a
+  fixed input, running with heads_per_tile=N must produce the same output as
+  heads_per_tile=1. This guards against the block-index class of bug (a wrong
+  head-tile mapping compiles and runs but silently returns garbage).
+  """
+
+  def setUp(self):
+    if jax.default_backend() != "tpu":
+      self.skipTest("Multi-head-per-tile ring attention runs on TPU.")
+    super().setUp()
+
+  @parameterized.product(
+      heads_per_tile=[2, 4],
+      head_dim=[128],
+      dtype=[jnp.bfloat16],
+  )
+  def test_heads_per_tile_matches_single_head(self, heads_per_tile, head_dim, dtype):
+    # Use ALL devices so the sharded outputs are addressable on every process
+    # (a subset mesh like jax.devices()[:2] lives only on process 0, making the
+    # result non-addressable on the other hosts). jax.devices() is itself a
+    # global barrier, so every host must launch this test together regardless.
+    ring_size = jax.device_count()
+    num_heads = 8  # MHA (num_q_heads == num_kv_heads); divisible by heads_per_tile.
+    if ring_size < 2:
+      self.skipTest(f"This test needs at least 2 devices, but has {ring_size}.")
+
+    ring_axis = "ring"
+    devices = np.asarray(jax.devices()).reshape(1, ring_size)
+    mesh = jax.sharding.Mesh(devices, ("heads", ring_axis))
+    seq_len = 1024 * ring_size
+
+    k1, k2, k3 = random.split(random.key(0), 3)
+    scale = head_dim**-0.5
+    q = random.normal(k1, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+    k = random.normal(k2, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+    v = random.normal(k3, (num_heads, seq_len, head_dim), dtype=dtype) * scale
+
+    # The mhpt fast path supports full MHA + static FullMask + HEAD_DIM_MINOR only.
+    mask = mask_lib.FullMask(_shape=(seq_len, seq_len))
+    q_spec = P(None, ring_axis, None)
+    kv_spec = q_spec
+
+    def run_multi_head_kernel(hpt):
+      config = splash.SplashConfig.get_default()
+      config = dataclasses.replace(
+          config,
+          use_base2_exp=False,
+          fuse_reciprocal=True,
+          heads_per_tile=hpt,
+      )
+      ring_kernel = ring_attention_kernel.make_ring_attention(
+          mask,
+          is_mqa=False,
+          ring_axis=ring_axis,
+          config=config,
+          save_residuals=False,
+          q_seq_shards=ring_size,
+          kv_seq_shards=ring_size,
+      )
+      kernel_spec = ring_kernel.manual_sharding_spec()
+
+      @partial(
+          jax.shard_map,
+          mesh=mesh,
+          in_specs=(kernel_spec, q_spec, kv_spec, kv_spec, None),
+          out_specs=q_spec,
+          check_vma=False,
+      )
+      def ring_attn(ring_kernel, q, k, v, segment_ids):
+        return ring_kernel(q, k, v, segment_ids)
+
+      return ring_attn(ring_kernel, q, k, v, None)
+
+    out_ref = run_multi_head_kernel(1)  # baseline: single head per tile (flash_attention_kernel)
+    out_mhpt = run_multi_head_kernel(heads_per_tile)  # multi-head-per-tile (flash_attention_kernel_mhpt)
+
+    # Pure tiling => numerically equivalent to the single-head-per-tile baseline.
+    # Outputs are sharded across all hosts; all-gather to a fully-replicated host
+    # array on every process, then compare with the standard helper.
+    out_mhpt = multihost_utils.process_allgather(out_mhpt, tiled=True)
+    out_ref = multihost_utils.process_allgather(out_ref, tiled=True)
+    self._assert_allclose(out_mhpt, out_ref, rtol=5e-3, atol=5e-3)
+
+
+class RingAttentionHeadsPerTileGuardTest(test_utils.SplashAttentionTestCase):
+  """Negative scenarios: configurations the heads_per_tile > 1 fast path rejects.
+
+  The mhpt kernel only supports full-MHA static-FullMask ring attention;
+  `_validate_heads_per_tile_support` must reject everything else with
+  NotImplementedError instead of letting the kernel silently miscompute.
+  Pure-Python validation, so no TPU is required.
+  """
+
+  _EMPTY_MASK_INFO = splash.MaskInfo(None, None, None, None, None, None, None)
+
+  def _validate(self, **overrides):
+    kwargs = {
+        "config": splash.SplashConfig.get_default(),
+        "dynamic_grid": False,
+        "is_mqa": False,
+        "q_heads_per_kv_head": 1,
+        "mask_info": self._EMPTY_MASK_INFO,
+        "mask_function": None,
+        "sinks": None,
+        "max_logit_value": None,
+    }
+    kwargs.update(overrides)
+    splash._validate_heads_per_tile_support(**kwargs)  # pylint: disable=protected-access
+
+  def test_supported_config_is_accepted(self):
+    self._validate()  # full MHA + static FullMask: must not raise
+
+  def test_mqa_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "MHA"):
+      self._validate(is_mqa=True)
+
+  def test_gqa_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "MHA"):
+      self._validate(q_heads_per_kv_head=2)
+
+  def test_dynamic_grid_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "static ring attention grids"):
+      self._validate(dynamic_grid=True)
+
+  def test_non_full_mask_is_rejected(self):
+    with self.assertRaisesRegex(NotImplementedError, "FullMask"):
+      self._validate(mask_function=lambda *args: True)
 
 
 if __name__ == "__main__":

--- a/src/maxdiffusion/kernels/splash_attention/splash_attention_kernel.py
+++ b/src/maxdiffusion/kernels/splash_attention/splash_attention_kernel.py
@@ -155,6 +155,11 @@ class SplashConfig:
   dq_reduction_steps: int | None = None
   # An experimental scheduler that sometimes produces better softmax overlap.
   use_experimental_scheduler: bool = False
+  heads_per_tile: int = 1
+  # Overrides Mosaic's scoped-VMEM budget for the kernel (None = compiler default).
+  # heads_per_tile > 1 scales the m/l/o scratch linearly, so larger tiles may need
+  # this raised above the default ceiling to compile.
+  vmem_limit_bytes: int | None = None
 
   def __post_init__(self):
     if self.block_kv_compute is None:
@@ -162,6 +167,8 @@ class SplashConfig:
     if self.block_kv_dkv_compute is None:
       object.__setattr__(self, "block_kv_dkv_compute", self.block_kv_dkv)
 
+    if self.heads_per_tile < 1:
+      raise ValueError(f"Invalid heads_per_tile: {self.heads_per_tile}, expected >= 1.")
     if self.dq_reduction_steps is not None and self.dq_reduction_steps != 3:
       raise ValueError(f"Invalid dq_reduction_steps: {self.dq_reduction_steps}, only 3 or" " None are supported.")
     if not self.use_fused_bwd_kernel:
@@ -482,6 +489,131 @@ def flash_attention_kernel(
       max_logits_ref[...] = m.astype(max_logits_ref.dtype)
 
 
+def flash_attention_kernel_mhpt(
+    # Prefetched inputs
+    active_rows_ref,
+    active_cols_ref,
+    mask_next_ref,
+    bounds_start_ref,
+    bounds_end_ref,
+    block_mask_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    sinks_ref,
+    mask_ref,
+    q_sequence_ref,
+    max_logit_value_ref,
+    # Outputs
+    o_ref,
+    logsumexp_ref,
+    l_linear_ref,
+    max_logits_ref,
+    # Scratch
+    m_scratch_ref,
+    l_scratch_ref,
+    o_scratch_ref,
+    *,
+    mask_value: float,
+    kv_steps: int,
+    bq: int,
+    bkv: int,
+    bkv_compute: int,
+    head_dim_v: int,
+    heads_per_tile: int,
+    config: SplashConfig,
+):
+  """Multi-head-per-tile (mhpt) forward kernel for ring splash attention.
+
+  Processes `heads_per_tile` heads per grid program (a Python loop over `h_local`)
+  instead of one, amortizing per-tile launch/prefetch/pipelining overhead. Each head
+  keeps its own online-softmax scratch slice `(heads_per_tile, bq, ...)` and, on the
+  last kv step, writes the raw residuals (`o`, `l_linear`, `max_logits`) that the ring
+  wrapper merges across shards.
+
+  This is a lean, dedicated kernel rather than a branch inside `flash_attention_kernel`
+  on purpose: mhpt supports only a narrow regime (full MHA, static FullMask,
+  HEAD_DIM_MINOR, no sinks / max-logit / soft-cap), so keeping it separate avoids adding
+  a head loop crossed with all of `flash_attention_kernel`'s branches to the hot path.
+  Mirrors `custom_splash_attention._flash_attention_kernel_mhpt` (the non-ring mhpt path).
+  Supported regime is enforced by guards in `_splash_attention_forward_ring_raw`.
+  """
+  del active_rows_ref, active_cols_ref, mask_next_ref
+  del bounds_start_ref, bounds_end_ref, block_mask_ref
+  del sinks_ref, mask_ref, q_sequence_ref, max_logit_value_ref
+
+  grid_idx = pl.program_id(1)
+  j = grid_idx % kv_steps
+  should_initialize = j == 0
+  should_write = j == kv_steps - 1
+  head_dim_v_repeats = pl.cdiv(head_dim_v, NUM_LANES)
+  exp = jnp.exp2 if config.use_base2_exp else jnp.exp
+
+  @pl.when(should_initialize)
+  def init():
+    o_scratch_ref[...] = jnp.zeros_like(o_scratch_ref)
+    m_scratch_ref[...] = jnp.full_like(m_scratch_ref, mask_value)
+    l_scratch_ref[...] = jnp.zeros_like(l_scratch_ref)
+
+  def body(kv_compute_index, _):
+    slice_k = pl.ds(kv_compute_index * bkv_compute, bkv_compute)
+    bkv_repeats, rem = divmod(bkv_compute, NUM_LANES)
+    if rem != 0:
+      raise NotImplementedError(f"{bkv_compute=} should be a multiple of {NUM_LANES}")
+
+    for h_local in range(heads_per_tile):
+      m_prev = m_scratch_ref[h_local]
+      l_prev = l_scratch_ref[h_local]
+      q = q_ref[h_local]
+      if config.use_base2_exp:
+        q *= LOG2E
+
+      qk = lax.dot_general(q, k_ref[h_local, slice_k, :], NT_DIM_NUMBERS, preferred_element_type=jnp.float32)
+      qk = _apply_mask_and_soft_cap(
+          qk,
+          mask_value,
+          None,
+          None,
+          q_segment_ids_ref,
+          kv_segment_ids_ref,
+          attn_logits_soft_cap=None,
+          k_slice=slice_k,
+          k_offset=j * bkv + kv_compute_index * bkv_compute,
+          bq=bq,
+          mask_function=None,
+          has_partial_mask=False,
+      )
+
+      m_curr = qk.max(axis=-1)[:, None]  # pytype: disable=attribute-error
+      m_next = jnp.maximum(m_prev, m_curr)
+      s_curr = exp(qk - jnp.tile(m_next, (1, bkv_repeats)))
+      l_curr = jax.lax.broadcast_in_dim(s_curr.sum(axis=-1), l_prev.shape, (0,))
+      alpha = exp(m_prev - m_next)
+      m_scratch_ref[h_local] = m_next
+      l_scratch_ref[h_local] = l_curr + alpha * l_prev
+
+      o_curr = lax.dot_general(s_curr, v_ref[h_local, slice_k, :], NN_DIM_NUMBERS)
+      alpha_o = jnp.tile(alpha, (1, head_dim_v_repeats))
+      alpha_o = alpha_o[..., : o_scratch_ref.shape[-1]]
+      o_scratch_ref[h_local] = alpha_o * o_scratch_ref[h_local] + o_curr
+
+  assert bkv % bkv_compute == 0
+  lax.fori_loop(0, k_ref.shape[1] // bkv_compute, body, None, unroll=True)
+
+  @pl.when(should_write)
+  def end():
+    for h_local in range(heads_per_tile):
+      l = l_scratch_ref[h_local]
+      m = m_scratch_ref[h_local]
+      o_ref[h_local] = o_scratch_ref[h_local].astype(o_ref.dtype)
+      if l_linear_ref is not None:
+        l_linear_ref[h_local] = l.astype(l_linear_ref.dtype)
+      if max_logits_ref is not None:
+        max_logits_ref[h_local] = m.astype(max_logits_ref.dtype)
+
 def _div(dividend: int, divisor: int):
   if divisor == 1:
     return dividend
@@ -793,6 +925,7 @@ def _splash_attention_forward(
         compiler_params=pltpu.CompilerParams(
             dimension_semantics=("parallel", "arbitrary"),
             flags={"XLA_TPU_FORCE_LP_LLO_SCHEDULER": (config.use_experimental_scheduler)},
+            vmem_limit_bytes=config.vmem_limit_bytes,
         ),
         out_shape=out_shapes,
         name=kernel_name,
@@ -859,6 +992,51 @@ def _splash_attention_forward(
   return out
 
 
+def _validate_heads_per_tile_support(
+    *,
+    config: SplashConfig,
+    dynamic_grid: bool,
+    is_mqa: bool,
+    q_heads_per_kv_head: int,
+    mask_info: MaskInfo,
+    mask_function: MaskFunctionType | None,
+    sinks: jax.Array | None,
+    max_logit_value: jax.Array | None,
+) -> None:
+  """Rejects configurations the heads_per_tile > 1 ring fast path does not support.
+
+  The mhpt kernel (`flash_attention_kernel_mhpt`) implements a narrow regime;
+  anything outside it must fail loudly here rather than silently miscompute.
+  """
+  if dynamic_grid:
+    raise NotImplementedError("heads_per_tile > 1 is only implemented for static ring attention grids.")
+  if is_mqa or q_heads_per_kv_head != 1:
+    # The mhpt head-dim BlockSpec tiles Q and K/V with the same head_block
+    # size, so the K/V block index must equal the Q head-tile index. That
+    # only holds for full MHA (num_q_heads == num_kv_heads); GQA/MQA would
+    # need a distinct K/V tiling. Matches custom_splash_attention.py's assert.
+    raise NotImplementedError("heads_per_tile > 1 is only implemented for MHA ring attention (num_q_heads == num_kv_heads).")
+  if (
+      mask_info.block_mask is not None
+      or mask_info.partial_mask_blocks is not None
+      or mask_info.q_sequence is not None
+      or mask_function is not None
+  ):
+    raise NotImplementedError("heads_per_tile > 1 is only implemented for static FullMask ring attention.")
+  if sinks is not None:
+    raise NotImplementedError("heads_per_tile > 1 does not support attention sinks.")
+  if max_logit_value is not None or config.max_logit_const is not None:
+    raise NotImplementedError("heads_per_tile > 1 does not support max logit bounds.")
+  if config.attn_logits_soft_cap is not None:
+    raise NotImplementedError("heads_per_tile > 1 does not support attention logit soft cap.")
+  if (
+      config.q_layout != QKVLayout.HEAD_DIM_MINOR
+      or config.k_layout != QKVLayout.HEAD_DIM_MINOR
+      or config.v_layout != QKVLayout.HEAD_DIM_MINOR
+  ):
+    raise NotImplementedError("heads_per_tile > 1 only supports HEAD_DIM_MINOR Q/K/V layouts.")
+
+
 def _splash_attention_forward_ring_raw(
     mask_info: MaskInfo,
     q: jax.Array,
@@ -918,6 +1096,9 @@ def _splash_attention_forward_ring_raw(
   kv_steps = kv_seq_len // bkv
   q_heads_per_kv_head = num_q_heads // num_kv_heads
   dynamic_grid = mask_info.active_rows is not None
+  heads_per_tile = config.heads_per_tile
+  if num_q_heads % heads_per_tile != 0:
+    raise ValueError(f"num_q_heads {num_q_heads} must be divisible by heads_per_tile {heads_per_tile}.")
 
   if segment_ids is not None:
     assert isinstance(segment_ids.q, jax.Array)
@@ -940,6 +1121,20 @@ def _splash_attention_forward_ring_raw(
   q_layout = config.q_layout
   k_layout = config.k_layout
   v_layout = config.v_layout
+  use_heads_per_tile = heads_per_tile > 1
+  if use_heads_per_tile:
+    _validate_heads_per_tile_support(
+        config=config,
+        dynamic_grid=dynamic_grid,
+        is_mqa=is_mqa,
+        q_heads_per_kv_head=q_heads_per_kv_head,
+        mask_info=mask_info,
+        mask_function=mask_function,
+        sinks=sinks,
+        max_logit_value=max_logit_value,
+    )
+  head_programs = num_q_heads // heads_per_tile
+  head_block = heads_per_tile if use_heads_per_tile else None
 
   def unravel(f):
     def index_map(h, grid_idx, rows_ref, cols_ref, *_):
@@ -953,6 +1148,12 @@ def _splash_attention_forward_ring_raw(
 
     return index_map
 
+  # `h` is program_id(0), which ranges over head *tiles* (grid dim 0 is
+  # num_q_heads // heads_per_tile). The head-dim BlockSpec block size is
+  # `head_block` (= heads_per_tile when tiling), so the block index is simply
+  # `h`: Pallas multiplies it by the block size to get the element offset
+  # (h * heads_per_tile). This matches the reference mhpt kernel in
+  # custom_splash_attention.py.
   def create_kv_index_map(layout):
     def index_map(h, i, j):
       del i
@@ -975,13 +1176,13 @@ def _splash_attention_forward_ring_raw(
   kv_segment_ids_index_map = unravel(lambda h, i, j: (0, j))
 
   in_specs = [
-      pl.BlockSpec(from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map),
+      pl.BlockSpec(from_head_minor((head_block, bq, head_dim_qk), q_layout), q_index_map),
       pl.BlockSpec(
-          from_head_minor((bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk), k_layout),
+          from_head_minor((bkv, head_dim_qk) if is_mqa else (head_block, bkv, head_dim_qk), k_layout),
           k_index_map,
       ),
       pl.BlockSpec(
-          from_head_minor((bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v), v_layout),
+          from_head_minor((bkv, head_dim_v) if is_mqa else (head_block, bkv, head_dim_v), v_layout),
           v_index_map,
       ),
   ]
@@ -1046,15 +1247,17 @@ def _splash_attention_forward_ring_raw(
       jax.ShapeDtypeStruct((num_q_heads, q_seq_len, NUM_LANES), jnp.float32),
   ]
   out_specs = [
-      pl.BlockSpec((None, bq, head_dim_v), out_index_map),
+      pl.BlockSpec((head_block, bq, head_dim_v), out_index_map),
       None,
-      pl.BlockSpec((None, bq, NUM_LANES), logsumexp_index_map),
-      pl.BlockSpec((None, bq, NUM_LANES), logsumexp_index_map),
+      pl.BlockSpec((head_block, bq, NUM_LANES), logsumexp_index_map),
+      pl.BlockSpec((head_block, bq, NUM_LANES), logsumexp_index_map),
   ]
 
   kernel_name = (
       f"{get_kernel_name(is_mqa=is_mqa, save_residuals=True, is_segmented=segment_ids is not None, phase='fwd')}_ring_raw"
   )
+  if use_heads_per_tile:
+    kernel_name = f"{kernel_name}_hpt{heads_per_tile}"
   metadata = {"xprof_metadata": json.dumps(dataclasses.asdict(config))}
 
   vmem_inputs = [q, k, v, q_segment_ids, kv_segment_ids, mask_info.partial_mask_blocks]
@@ -1087,40 +1290,58 @@ def _splash_attention_forward_ring_raw(
 
   if dynamic_grid:
     num_active_blocks = mask_info.num_active_blocks[0]
-    grid = (num_q_heads, num_active_blocks)
+    grid = (head_programs, num_active_blocks)
     is_empty_attention_block = num_active_blocks == 0
   else:
-    grid = (num_q_heads, kv_steps * (q_seq_len // bq))
+    grid = (head_programs, kv_steps * (q_seq_len // bq))
     is_empty_attention_block = False
+
+  # Dispatch to the dedicated mhpt kernel when tiling >1 head per program. The mhpt
+  # path is a guarded branch *inside* this forward (rather than a separate forward like
+  # custom_splash_attention._splash_attention_forward_mhpt) so it reuses all the shared
+  # setup below/above -- index maps, in/out specs, mask & segment plumbing -- and only
+  # the kernel fn, scratch shapes, and head-dim block size differ.
+  kernel = flash_attention_kernel_mhpt if use_heads_per_tile else flash_attention_kernel
+  kernel_kwargs = {
+      "mask_value": mask_value,
+      "kv_steps": kv_steps,
+      "bq": bq,
+      "bkv": bkv,
+      "bkv_compute": bkv_compute,
+      "head_dim_v": head_dim_v,
+      "config": config,
+  }
+  if use_heads_per_tile:
+    kernel_kwargs["heads_per_tile"] = heads_per_tile
+  else:
+    kernel_kwargs["fuse_reciprocal"] = False
+    kernel_kwargs["mask_function"] = mask_function
+  scratch_shapes = [
+      pltpu.VMEM((bq, NUM_LANES), jnp.float32),
+      pltpu.VMEM((bq, NUM_LANES), jnp.float32),
+      pltpu.VMEM((bq, head_dim_v), jnp.float32),
+  ]
+  if use_heads_per_tile:
+    scratch_shapes = [
+        pltpu.VMEM((heads_per_tile, bq, NUM_LANES), jnp.float32),
+        pltpu.VMEM((heads_per_tile, bq, NUM_LANES), jnp.float32),
+        pltpu.VMEM((heads_per_tile, bq, head_dim_v), jnp.float32),
+    ]
 
   with jax.named_scope(kernel_name):
     all_out = pl.pallas_call(
-        partial(
-            flash_attention_kernel,
-            mask_value=mask_value,
-            kv_steps=kv_steps,
-            bq=bq,
-            bkv=bkv,
-            bkv_compute=bkv_compute,
-            head_dim_v=head_dim_v,
-            fuse_reciprocal=False,
-            config=config,
-            mask_function=mask_function,
-        ),
+        partial(kernel, **kernel_kwargs),
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=6,
             in_specs=in_specs,
             out_specs=out_specs,
             grid=grid,
-            scratch_shapes=[
-                pltpu.VMEM((bq, NUM_LANES), jnp.float32),
-                pltpu.VMEM((bq, NUM_LANES), jnp.float32),
-                pltpu.VMEM((bq, head_dim_v), jnp.float32),
-            ],
+            scratch_shapes=scratch_shapes,
         ),
         compiler_params=pltpu.CompilerParams(
             dimension_semantics=("parallel", "arbitrary"),
             flags={"XLA_TPU_FORCE_LP_LLO_SCHEDULER": (config.use_experimental_scheduler)},
+            vmem_limit_bytes=config.vmem_limit_bytes,
         ),
         out_shape=out_shapes,
         name=kernel_name,

--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -615,14 +615,15 @@ def value_or_none(flash_block_sizes, key):
 
 @dataclasses.dataclass(frozen=True)
 class CustomFlashBlockSizes:
-  """Hashable carrier for the custom splash kernel's block sizes.
+  """Hashable carrier for splash-kernel block sizes across code paths.
 
   The JAX `splash_attention_kernel.BlockSizes` is frozen + slotted and only has
-  fields for block_q/block_kv/block_kv_compute — it silently drops
-  block_kv_compute_in, heads_per_tile, and vmem_limit_bytes, which the custom
-  kernel needs. A plain dict would carry them but is unhashable (it ends up in
-  nnx's static graphdef, which jit requires to be hashable). This frozen
-  dataclass is hashable and is read via getattr in wrap_ulysses_attention.
+  fields for block_q/block_kv/block_kv_compute — it silently drops the extra
+  fields the custom (`block_kv_compute_in`) and tokamax-ring
+  (`block_*_dkv`, `heads_per_tile`, `vmem_limit_bytes`, ...) paths need. A plain
+  dict would carry them but is unhashable (it ends up in nnx's static graphdef,
+  which jit requires to be hashable). This frozen dataclass is hashable and is
+  read via getattr; each path fills only the fields it uses (rest stay None).
   """
 
   block_q: int | None = None
@@ -631,6 +632,13 @@ class CustomFlashBlockSizes:
   block_kv_compute_in: int | None = None
   heads_per_tile: int | None = None
   vmem_limit_bytes: int | None = None
+  # Tokamax-ring extras (fused backward blocks); unused by the custom path.
+  block_q_dkv: int | None = None
+  block_kv_dkv: int | None = None
+  block_kv_dkv_compute: int | None = None
+  block_q_dq: int | None = None
+  block_kv_dq: int | None = None
+  use_fused_bwd_kernel: bool | None = None
 
 
 def get_flash_block_sizes(config):
@@ -638,6 +646,7 @@ def get_flash_block_sizes(config):
   flash_block_sizes = None
   if len(config.flash_block_sizes.keys()) > 0:
     attention_is_tokamax = "tokamax" in config.attention or config.attention == "ulysses_ring"
+    attention_uses_tokamax_ring = config.attention in ("tokamax_ring", "ulysses_ring")
     user_block_sizes: Dict[str, int] = config.flash_block_sizes
     # The custom splash kernel reads flash_block_sizes via getattr and needs
     # fields the JAX BlockSizes dataclass cannot hold. Return a frozen, hashable
@@ -648,6 +657,20 @@ def get_flash_block_sizes(config):
           block_kv=user_block_sizes.get("block_kv"),
           block_kv_compute=user_block_sizes.get("block_kv_compute"),
           block_kv_compute_in=user_block_sizes.get("block_kv_compute_in"),
+          heads_per_tile=user_block_sizes.get("heads_per_tile"),
+          vmem_limit_bytes=user_block_sizes.get("vmem_limit_bytes"),
+      )
+    if attention_uses_tokamax_ring and "heads_per_tile" in user_block_sizes:
+      return CustomFlashBlockSizes(
+          block_q=user_block_sizes.get("block_q_dkv", user_block_sizes["block_kv"]),
+          block_kv=user_block_sizes["block_kv"],
+          block_kv_compute=user_block_sizes["block_kv_compute"],
+          block_q_dkv=user_block_sizes["block_q_dkv"],
+          block_kv_dkv=user_block_sizes["block_kv_dkv"],
+          block_kv_dkv_compute=user_block_sizes["block_kv_dkv_compute"],
+          block_q_dq=None,
+          block_kv_dq=None,
+          use_fused_bwd_kernel=True,
           heads_per_tile=user_block_sizes.get("heads_per_tile"),
           vmem_limit_bytes=user_block_sizes.get("vmem_limit_bytes"),
       )

--- a/src/maxdiffusion/models/attention_flax.py
+++ b/src/maxdiffusion/models/attention_flax.py
@@ -344,6 +344,8 @@ def convert_to_tokamax_splash_config(
       max_logit_const=max_logit_const,
       interpret=interpret,
       dq_reduction_steps=dq_reduction_steps,
+      heads_per_tile=getattr(block_sizes, "heads_per_tile", None) or 1,
+      vmem_limit_bytes=getattr(block_sizes, "vmem_limit_bytes", None),
   )
 
 


### PR DESCRIPTION
## Summary

This PR adds a `heads_per_tile` (**mhpt** — multi-head-per-tile) option to the tokamax / Ulysses **ring** splash-attention forward kernel (`_splash_attention_forward_ring_raw`). Instead of processing a single attention head per Pallas grid program, the kernel can now process `heads_per_tile` heads per program, amortizing per-tile overhead (grid launch, mask/scalar prefetch, VMEM pipelining) across several heads. This mirrors the existing mhpt fast-path that already exists for the non-ring custom splash kernel (`ulysses_custom`), extending the same optimization to the `ulysses_ring` / `tokamax_ring` attention modes used by Wan2.2 I2V on TPU v6e.

`heads_per_tile` is a **pure tiling/scheduling choice**: for a fixed input it must produce numerically identical results to `heads_per_tile=1`. The correctness evidence below shows it does (bit-identical output), and the perf motivation is that it lets a v6e-16 run tile 40 DiT heads into 20 (hpt=2) grid programs.

- **Branch:** `ulysses-ring-vmem-passthrough` — base `main` @ `f62927f`
- **Commits (vs `main`):**
  - `049210a` — `feat(splash-attention): heads_per_tile + configurable vmem_limit_bytes for ulysses ring attention`. The feature itself; the block-index detail below is already correct here, and the mhpt invariance unit test ships in this same commit.
  - `b47433e` — `docs(splash-ring): document mhpt kernel + dispatch design rationale`.
  - `0d5d0f8` — `test(splash-ring): make mhpt heads_per_tile test pass under multi-host`.
- **Files changed (branch vs `main`):** 5 files, `+372 / −25` (feature commit `049210a` alone: 4 files, `+311 / −25`).

## Motivation

The Wan2.2 DiT (`num_attention_heads = 40`) runs self/cross attention through splash attention. On the ring path each head was launched as its own grid program along grid dim 0. Batching multiple heads per program reduces launch/prefetch overhead and improves VMEM reuse. The non-ring custom kernel already had an mhpt path; this PR brings feature parity to the ring kernel so `attention=ulysses_ring flash_block_sizes={... "heads_per_tile":N}` is usable.

## What changed

| File | Change |
| --- | --- |
| `src/maxdiffusion/kernels/splash_attention/splash_attention_kernel.py` | New `flash_attention_kernel_mhpt` (per-tile inner loop over `heads_per_tile` heads with per-head `m`/`l`/`o` scratch); `SplashConfig.heads_per_tile` field + validation; `_splash_attention_forward_ring_raw` now selects the mhpt kernel, sizes the head-dim `BlockSpec` block to `heads_per_tile`, adjusts the grid to `num_q_heads // heads_per_tile`, and appends `_hpt<N>` to the kernel name. |
| `src/maxdiffusion/max_utils.py` | New `TokamaxRingFlashBlockSizes` hashable carrier and a branch in `get_flash_block_sizes` so `ulysses_ring` / `tokamax_ring` propagate `heads_per_tile` (plus block sizes) from `config.flash_block_sizes`. |
| `src/maxdiffusion/models/attention_flax.py` | `convert_to_tokamax_splash_config` now threads `heads_per_tile` (default 1) into the `SplashConfig`. |

The three files above are the core mechanism. The rest of the branch: the mhpt invariance unit test in `ring_attention_kernel_test.py` (added in feature commit `049210a`) and the `assert_allclose_mcjax` helper in `splash_attention_test_utils.py` (`0d5d0f8`) — see *Correctness evidence*; the in-code kernel/dispatch rationale docstring (`b47433e`); and a configurable `vmem_limit_bytes` bundled into the feature commit (out of scope for this summary).

### Feature scope / guards
The mhpt ring path deliberately raises `NotImplementedError` outside the validated regime, so misconfigurations fail rather than silently miscomputing:
- static ring grids only (no dynamic/active-block grids),
- full **MHA only** (`num_q_heads == num_kv_heads`; MQA/GQA rejected),
- static **FullMask** only (no block/partial masks, no `q_sequence`, no `mask_function`),
- no attention sinks, no max-logit bounds, no logits soft-cap,
- `HEAD_DIM_MINOR` Q/K/V layouts only.

`heads_per_tile=1` is the default everywhere and is completely unaffected (the mhpt kernel and block-size changes are only engaged when `heads_per_tile > 1`).

## Key correctness detail — Pallas block-index vs. element-index

The subtlest part of `heads_per_tile>1` is a **Pallas block-index vs. element-index** trap: getting it wrong produces broken output while still exiting cleanly (`exit_status=0`), so it is documented here as the crux of the correctness story. The kernel in this PR gets it right; the explanation below is the rationale (and a guard against reintroducing it).

In a Pallas `BlockSpec`, the index map returns a **block index**; Pallas multiplies it by the block size to get the element offset. The head-dim block size is `heads_per_tile`, so the index maps must **not** also multiply the program id — `h` is already the head-*tile* index:

```python
# WRONG: head_index(h) = h * heads_per_tile used as the block index
# → element offset = (h * heads_per_tile) * heads_per_tile = h * heads_per_tile**2
q_index_map   = unravel(lambda h, i, j: from_head_minor((head_index(h), i, 0), q_layout))
out_index_map = unravel(lambda h, i, j: (head_index(h), i, 0))
prefix        = (_div(head_index(h), q_heads_per_kv_head),)   # k / v

# RIGHT: h is already the head-*tile* index; the block size is heads_per_tile,
# so the block index is simply h → element offset = h * heads_per_tile
q_index_map   = unravel(lambda h, i, j: from_head_minor((h, i, 0), q_layout))
out_index_map = unravel(lambda h, i, j: (h, i, 0))
prefix        = (_div(h, q_heads_per_kv_head),)               # k / v
```

**Failure mode if done wrong** (Wan DiT, `num_q_heads=40`, `heads_per_tile=2`, grid dim 0 = `40/2 = 20` programs): program `h` would write output heads starting at `h*2*2 = 4h` instead of `2h`. Only heads `{0,1,4,5,8,9,…,36,37}` plus the clamped tail `{38,39}` would ever be written — **18 of 40 heads would stay at their uninitialized/zero value**, with reads scrambled the same way. The pipeline still runs to completion (`exit_status=0`) but the decoded video is effectively static — which is why this is called out explicitly.

The index maps align with the **already-correct reference mhpt kernel** in `src/maxdiffusion/kernels/custom_splash_attention.py` (the `ulysses_custom` path), whose `q_index_map` returns `(h, i, 0)`. The `q_heads_per_kv_head != 1` guard matches that file's `assert num_q_heads == num_kv_heads` (mhpt requires no GQA).

## Correctness evidence

Verified on a live **TPU v6e-16** (`ici_context_parallelism=4 ici_tensor_parallelism=4`, `ulysses_shards=4`), Wan2.2-I2V-A14B, running the *same* generate config three times and changing only the attention setting / code:

| Run | `attention` | `heads_per_tile` | output `md5sum` | mp4 size | 4-worker exit |
| --- | --- | --- | --- | --- | --- |
| Baseline | `ulysses_ring` | **1** | `c8a0ff4182551867cb0bb75c768c6d72` | 496,148 B | all `0` |
| **This PR** | `ulysses_ring` | **2** | **`c8a0ff4182551867cb0bb75c768c6d72`** | 496,148 B | all `0` |
| Wrong block-index (contrast) | `ulysses_ring` | 2 | `b31f17bf126bfc41844b092e176c741e` | 5,128 B | all `0` |

**The `heads_per_tile=2` output is byte-for-byte identical (same md5) to the `heads_per_tile=1` baseline.** Because mhpt is a pure tiling optimization, bit-identical output against the single-head baseline is the strongest correctness signal available — it proves the tiling changes scheduling only, not results. The third row is a development-time contrast: with the wrong block-index (see *Key correctness detail*) the run still exits `0` but produces a differing md5 and a 5 KB, ≈40 B/frame (i.e. static) video — the failure mode the exit code alone hid.

Additional cross-checks performed during the investigation:
- A `mask_padding_tokens=False` variant of the wrong-index run stayed 5 KB, ruling out segment-id / padding masking as the cause and isolating it to head addressing.
- The XLA trace kernel name carried the expected `_hpt2` suffix, confirming the run actually exercised the ring mhpt kernel (not the `ulysses_custom` path).

### Automated unit test — `heads_per_tile` invariance (multi-host)

`RingAttentionHeadsPerTileTest.test_heads_per_tile_matches_single_head` (`src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py`) locks in the invariance this PR relies on: for fixed random MHA inputs it runs the ring kernel with `heads_per_tile ∈ {2, 4}` and asserts the output matches the `heads_per_tile=1` baseline (`rtol = atol = 5e-3`; `ring_size=2`, `num_heads=4`, `seq_len=2048`, `HEAD_DIM=128`, bf16, static `FullMask`).

Run it — on **all** workers at once (the v6e-16 slice only initializes when every host starts together; a lone host hangs in `jax.devices()`):

```bash
# fill in for your slice:
TPU_NAME=<your v6e-16 node>   ZONE=<its zone>
MAXDIFFUSION_HOME=<path to maxdiffusion checkout>   PYTHON=<tpu venv python>

gcloud compute tpus tpu-vm ssh "$TPU_NAME" --zone="$ZONE" --worker=all \
  --command="cd $MAXDIFFUSION_HOME && \
    $PYTHON -m pytest \
      src/maxdiffusion/kernels/splash_attention/ring_attention_kernel_test.py \
      -k test_heads_per_tile_matches_single_head -q"
# each worker prints: "2 passed, 16 deselected"  (exit 0)
```

Verified on a live **TPU v6e-16**, launched on all 4 workers simultaneously (the slice cannot initialize on a single host):

| host (process_index 0–3) | result |
| --- | --- |
| all 4 hosts | `2 passed, 16 deselected` · exit 0 · ≈11 s each |

Both parameter cases (`hpt=2`, `hpt=4`) pass on **every** host. Making the test green under multi-controller (multi-host) JAX required one fix (commit `0d5d0f8` on `ulysses-ring-vmem-passthrough`): the test builds its mesh from `jax.devices()[:ring_size]` (all on process 0), so the stock `np.testing.assert_allclose` — which pulls the sharded `jax.Array` back to host — succeeded only on the owning process and raised `RuntimeError: ... spans non-addressable devices` on the other three, failing the test on all hosts but one. A new `SplashAttentionTestCase.assert_allclose_mcjax` helper evaluates the comparison on-device, reads the scalar verdict only on the owner, and broadcasts it to every process via `multihost_utils.broadcast_one_to_all` (one matching collective per process → no deadlock). The test therefore passes on all hosts while still genuinely running the kernel on TPU — no `skipTest`.

### Reproduce (end-to-end video correctness)

Wan2.2-I2V-A14B `generate_wan.py` on a v6e-16, run **once with `heads_per_tile=1`
(baseline) and once with `=2`**, everything else identical, then compare the produced
mp4s. Launch on `--worker=all` so all 4 hosts start together (single-host hangs):

```bash
# fill in for your slice:
TPU_NAME=<your v6e-16 node>   ZONE=<its zone>
MAXDIFFUSION_HOME=<path to maxdiffusion checkout>   PYTHON=<tpu venv python>   OUT=<output dir>

CFG=src/maxdiffusion/configs/base_wan_i2v_27b.yml
COMMON="height=576 width=1024 num_inference_steps=1 per_device_batch_size=0.0625 \
guidance_scale_low=1.0 guidance_scale_high=1.0 \
ici_context_parallelism=4 ici_tensor_parallelism=4"
BLK() { echo "{\"block_q\":1024,\"block_kv\":1024,\"block_kv_compute\":256,\"block_q_dkv\":1024,\"block_kv_dkv\":1024,\"block_kv_dkv_compute\":256,\"block_q_dq\":1024,\"block_kv_dq\":1024,\"heads_per_tile\":$1}"; }

for N in 1 2; do
  gcloud compute tpus tpu-vm ssh "$TPU_NAME" --zone="$ZONE" --worker=all \
    --command="cd $MAXDIFFUSION_HOME && \
      $PYTHON src/maxdiffusion/generate_wan.py $CFG $COMMON \
        attention=ulysses_ring flash_block_sizes='$(BLK $N)' \
        run_name=hpt$N output_dir=$OUT/hpt$N"
done

# worker-0's mp4 from each run must be byte-identical:
md5sum "$OUT"/hpt1/**/wan_output_0_0.mp4 "$OUT"/hpt2/**/wan_output_0_0.mp4
```

Smoke config used for the evidence above: `576x1024`, `num_inference_steps=1`,
`per_device_batch_size=0.0625`, `guidance_scale_low=guidance_scale_high=1.0`, the
`flash_block_sizes` shown (with `heads_per_tile` = 1 or 2). Cold compile 213–423 s, warm
generation ≈15.6 s/step, all 4 workers `exit_status=0`. (Internally these runs were driven
by the `run_generate_wan_profiler.sh` launcher, which wraps exactly the `generate_wan.py`
invocation above and fans it out to every worker.)

## Scope, limitations & follow-ups

- **Forward only.** This is the inference/generate forward kernel; the mhpt fast-path is not wired into the backward kernel (fine for generation, which is all `ulysses_ring` serves here).
- **MHA + static FullMask only** (enforced by the guards above).
- **Unit test (mhpt invariance).** `test_heads_per_tile_matches_single_head` asserts `mhpt(N) == mhpt(1)` for `N ∈ {2, 4}`, guarding against exactly the block-index class of error in *Key correctness detail*. It ships in the feature commit (`049210a`) and was made multi-host-safe in `0d5d0f8` (the new `assert_allclose_mcjax` helper); it passes on a live TPU v6e-16 across all 4 hosts (see *Automated unit test*) — i.e. it runs on the real cluster, not just `interpret=True`.