### PR TITLE
Fix: bump libtpu version to resolve TPU v7x device initialization failure

### DIFF
--- a/dependencies/requirements/base_requirements/requirements.txt
+++ b/dependencies/requirements/base_requirements/requirements.txt
@@ -17,6 +17,7 @@ imageio
 jax
 jaxlib
 jaxopt
+libtpu>=0.0.42.1
 Jinja2
 opencv-python-headless
 optax

--- a/dependencies/requirements/generated_requirements/requirements.txt
+++ b/dependencies/requirements/generated_requirements/requirements.txt
@@ -89,7 +89,7 @@ keras>=3.13.1
 kiwisolver>=1.4.9
 lazy-loader>=0.5
 libclang>=18.1.1
-libtpu>=0.0.34 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+libtpu>=0.0.42.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 markdown-it-py>=4.0.0
 markdown>=3.10.1
 markupsafe>=3.0.3

--- a/setup.sh
+++ b/setup.sh
@@ -161,8 +161,18 @@ elif [[ $MODE == "nightly" ]]; then
     python3 -m uv pip install --pre -U jax -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
     # Install jaxlib-nightly
     python3 -m uv pip install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-    # Install libtpu-nightly
-    python3 -m uv pip install --pre -U libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+    # Install libtpu (clean up any conflicting libtpu_nightly if present)
+    python3 -m uv pip uninstall libtpu_nightly 2>/dev/null || true
+    if [[ -n "$LIBTPU_WHEEL_URL" ]]; then
+      echo "Installing custom libtpu from ${LIBTPU_WHEEL_URL}"
+      python3 -m uv pip install -U "${LIBTPU_WHEEL_URL}"
+    elif [[ -n "$LIBTPU_VERSION" ]]; then
+      echo "Installing libtpu version ${LIBTPU_VERSION}"
+      python3 -m uv pip install -U "libtpu==${LIBTPU_VERSION}"
+    else
+      echo "Installing verified libtpu (>=0.0.42.1)"
+      python3 -m uv pip install -U "libtpu>=0.0.42.1"
+    fi
   fi
   echo "Installing nightly tensorboard plugin profile"
   python3 -m uv pip install tbp-nightly --upgrade


### PR DESCRIPTION
## Problem
Nightly regression tests running on Ironwood (`tpu7x`) using `maxdiffusion_jax_nightly:latest` fail on startup during `jax.device_count()` with:
```text
WARNING: No hardware is found. Using default TPU version: ba16c7433
RuntimeError: Unable to initialize backend 'tpu': UNKNOWN: TPU initialization failed: No ba16c7433 device found.
```
Fix:

- Bump minimum libtpu to >=0.0.42.1 in requirements and setup.sh to ensure compatibility with TPU v7x (Ironwood) hardware.
- Avoid conflicting libtpu_nightly installations in setup.sh that collide with libtpu.